### PR TITLE
Add tests for ICollection<>-based Combine() extensions

### DIFF
--- a/DynamicData.Tests/CacheFixtures/AndFixture.cs
+++ b/DynamicData.Tests/CacheFixtures/AndFixture.cs
@@ -1,30 +1,46 @@
-
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using DynamicData.Tests.Domain;
 using NUnit.Framework;
 
 namespace DynamicData.Tests.CacheFixtures
 {
-
-
+    [TestFixture]
+    public class AndFixture : AndFixtureBase
+    {
+        protected override IObservable<IChangeSet<Person, string>> CreateObservable()
+        {
+            return _source1.Connect().And(_source2.Connect());
+        }
+    }
 
     [TestFixture]
-    public class AndFixture
+    public class AndCollectionFixture : AndFixtureBase
     {
-        private ISourceCache<Person, string> _source1;
-        private ISourceCache<Person, string> _source2;
+        protected override IObservable<IChangeSet<Person, string>> CreateObservable()
+        {
+            var l = new List<IObservable<IChangeSet<Person, string>>> { _source1.Connect(), _source2.Connect() };
+            return l.And();
+        }
+    }
+
+    [TestFixture]
+    public abstract class AndFixtureBase
+    {
+        protected ISourceCache<Person, string> _source1;
+        protected ISourceCache<Person, string> _source2;
         private ChangeSetAggregator<Person, string> _results;
-        private IDisposable _itemChanges;
 
         [SetUp]
         public void Initialise()
         {
             _source1 = new SourceCache<Person, string>(p => p.Name);
             _source2 = new SourceCache<Person, string>(p => p.Name);
-            _results = _source1.Connect().And(_source2.Connect()).AsAggregator();
-
+            _results = CreateObservable().AsAggregator();
         }
+
+        protected abstract IObservable<IChangeSet<Person, string>> CreateObservable();
 
         [TearDown]
         public void Cleanup()

--- a/DynamicData.Tests/ListFixtures/AndFixture.cs
+++ b/DynamicData.Tests/ListFixtures/AndFixture.cs
@@ -1,13 +1,34 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
 namespace DynamicData.Tests.ListFixtures
 {
     [TestFixture]
-    public class AndFixture
+    public class AndFixture : AndFixtureBase
     {
-        private ISourceList<int> _source1;
-        private ISourceList<int> _source2;
+        protected override IObservable<IChangeSet<int>> CreateObservable()
+        {
+            return _source1.Connect().And(_source2.Connect());
+        }
+    }
+
+    [TestFixture]
+    public class AndCollectionFixture : AndFixtureBase
+    {
+        protected override IObservable<IChangeSet<int>> CreateObservable()
+        {
+            var l = new List<IObservable<IChangeSet<int>>> {_source1.Connect(), _source2.Connect()};
+            return l.And();
+        }
+    }
+
+    [TestFixture]
+    public abstract class AndFixtureBase
+    {
+        protected ISourceList<int> _source1;
+        protected ISourceList<int> _source2;
         private ChangeSetAggregator<int> _results;
 
         [SetUp]
@@ -15,8 +36,10 @@ namespace DynamicData.Tests.ListFixtures
         {
             _source1 = new SourceList<int>();
             _source2 = new SourceList<int>();
-            _results = _source1.Connect().And(_source2.Connect()).AsAggregator();
+            _results = CreateObservable().AsAggregator();
         }
+
+        protected abstract IObservable<IChangeSet<int>> CreateObservable();
 
         [TearDown]
         public void Cleanup()

--- a/DynamicData.Tests/ListFixtures/ExceptFixture.cs
+++ b/DynamicData.Tests/ListFixtures/ExceptFixture.cs
@@ -1,13 +1,34 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
 namespace DynamicData.Tests.ListFixtures
 {
     [TestFixture]
-    public class ExceptFixture
+    public class ExceptFixture : ExceptFixtureBase
     {
-        private ISourceList<int> _source1;
-        private ISourceList<int> _source2;
+        protected override IObservable<IChangeSet<int>> CreateObservable()
+        {
+            return _source1.Connect().Except(_source2.Connect());
+        }
+    }
+
+    [TestFixture]
+    public class ExceptCollectionFixture : ExceptFixtureBase
+    {
+        protected override IObservable<IChangeSet<int>> CreateObservable()
+        {
+            var l = new List<IObservable<IChangeSet<int>>> {_source1.Connect(), _source2.Connect()};
+            return l.Except();
+        }
+    }
+
+    [TestFixture]
+    public abstract class ExceptFixtureBase
+    {
+        protected ISourceList<int> _source1;
+        protected ISourceList<int> _source2;
         private ChangeSetAggregator<int> _results;
 
         [SetUp]
@@ -15,8 +36,10 @@ namespace DynamicData.Tests.ListFixtures
         {
             _source1 = new SourceList<int>();
             _source2 = new SourceList<int>();
-            _results = _source1.Connect().Except(_source2.Connect()).AsAggregator();
+            _results = CreateObservable().AsAggregator();
         }
+
+        protected abstract IObservable<IChangeSet<int>> CreateObservable();
 
         [TearDown]
         public void Cleanup()

--- a/DynamicData.Tests/ListFixtures/OrFixture.cs
+++ b/DynamicData.Tests/ListFixtures/OrFixture.cs
@@ -1,15 +1,34 @@
-﻿using System.Linq;
-using DynamicData.Tests.Domain;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
-using DynamicData;
 
 namespace DynamicData.Tests.ListFixtures
 {
     [TestFixture]
-    public class OrFixture
+    public class OrFixture : OrFixtureBase
     {
-        private ISourceList<int> _source1;
-        private ISourceList<int> _source2;
+        protected override IObservable<IChangeSet<int>> CreateObservable()
+        {
+            return _source1.Connect().Or(_source2.Connect());
+        }
+    }
+
+    [TestFixture]
+    public class OrCollectionFixture : OrFixtureBase
+    {
+        protected override IObservable<IChangeSet<int>> CreateObservable()
+        {
+            var list = new List<IObservable<IChangeSet<int>>> {_source1.Connect(), _source2.Connect()};
+            return list.Or();
+        }
+    }
+
+    [TestFixture]
+    public abstract class OrFixtureBase
+    {
+        protected ISourceList<int> _source1;
+        protected ISourceList<int> _source2;
         private ChangeSetAggregator<int> _results;
 
         [SetUp]
@@ -17,8 +36,10 @@ namespace DynamicData.Tests.ListFixtures
         {
             _source1 = new SourceList<int>();
             _source2 = new SourceList<int>();
-            _results = _source1.Connect().Or(_source2.Connect()).AsAggregator();
+            _results = CreateObservable().AsAggregator();
         }
+
+        protected abstract IObservable<IChangeSet<int>> CreateObservable();
 
         [TearDown]
         public void Cleanup()

--- a/DynamicData.Tests/ListFixtures/XOrFixture.cs
+++ b/DynamicData.Tests/ListFixtures/XOrFixture.cs
@@ -1,13 +1,34 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 
 namespace DynamicData.Tests.ListFixtures
 {
     [TestFixture]
-    public class XOrFixture
+    public class XOrFixture : XOrFixtureBase
     {
-        private ISourceList<int> _source1;
-        private ISourceList<int> _source2;
+        protected override IObservable<IChangeSet<int>> CreateObservable()
+        {
+            return _source1.Connect().Xor(_source2.Connect());
+        }
+    }
+
+    [TestFixture]
+    public class XOrCollectionFixture : XOrFixtureBase
+    {
+        protected override IObservable<IChangeSet<int>> CreateObservable()
+        {
+            var l = new List<IObservable<IChangeSet<int>>> { _source1.Connect(), _source2.Connect() };
+            return l.Xor();
+        }
+    }
+
+    [TestFixture]
+    public abstract class XOrFixtureBase
+    {
+        protected ISourceList<int> _source1;
+        protected ISourceList<int> _source2;
         private ChangeSetAggregator<int> _results;
 
         [SetUp]
@@ -15,8 +36,10 @@ namespace DynamicData.Tests.ListFixtures
         {
             _source1 = new SourceList<int>();
             _source2 = new SourceList<int>();
-            _results = _source1.Connect().Xor(_source2.Connect()).AsAggregator();
+            _results = CreateObservable().AsAggregator();
         }
+
+        protected abstract IObservable<IChangeSet<int>> CreateObservable();
 
         [TearDown]
         public void Cleanup()


### PR DESCRIPTION
Refactor existing Combine() tests by introducing base classes.
This is done to avoid having duplicate code in the tests.