### PR TITLE
Fix bug when subscribing to MutableFilter multiple times

### DIFF
--- a/DynamicData.Tests/ListFixtures/FilterFixture.cs
+++ b/DynamicData.Tests/ListFixtures/FilterFixture.cs
@@ -1,4 +1,7 @@
-﻿using System.Linq;
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using DynamicData.Controllers;
 using DynamicData.Tests.Domain;
 using NUnit.Framework;
 
@@ -208,6 +211,21 @@ namespace DynamicData.Tests.ListFixtures
 
 			Assert.AreEqual(0, _results.Messages.Count, "Should be no updates");
             Assert.AreEqual(0, _results.Data.Count, "Should nothing cached");
+        }
+
+        [Test]
+        public void FilterSubscribedToMultipleTimes()
+        {
+            var source = new SourceList<Person>();
+            var filtered = source.Connect()
+                                  .Filter(new FilterController<Person>(person => true));
+
+            filtered.Subscribe();
+
+            filtered.Filter(new FilterController<Person>(person => true))
+                    .Subscribe();
+
+            Assert.DoesNotThrow(() => source.Add(new Person("test", 1)));
         }
     }
 }

--- a/DynamicData/List/Internal/MutableFilter.cs
+++ b/DynamicData/List/Internal/MutableFilter.cs
@@ -1,141 +1,132 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using DynamicData.Annotations;
-using DynamicData.Controllers;
-using DynamicData.Kernel;
 
 namespace DynamicData.Internal
 {
     //TODO: Implement seperate ClearAndReplace and CalculateDiffSet filters??
-
     internal class MutableFilter<T>
-	{
-		private readonly List<ItemWithMatch> _allWithMatch = new List<ItemWithMatch>();
-        private readonly List<T> _all = new List<T>();
-        private readonly ChangeAwareList<T> _filtered = new ChangeAwareList<T>();
-
-
-	    private readonly FilterPolicy _filterPolicy;
+    {
+        private readonly FilterPolicy _filterPolicy;
         private readonly IObservable<IChangeSet<T>> _source;
         private readonly IObservable<Func<T, bool>> _predicates;
 
+        private Func<T, bool> _predicate = t => false;
 
-        private Func<T, bool> _predicate=t=>false;
-
-		public MutableFilter([NotNull] IObservable<IChangeSet<T>> source, 
+        public MutableFilter([NotNull] IObservable<IChangeSet<T>> source,
             [NotNull] IObservable<Func<T, bool>> predicates,
-            FilterPolicy filterPolicy= FilterPolicy.ClearAndReplace)
-		{
-			if (source == null) throw new ArgumentNullException(nameof(source));
-			if (predicates == null) throw new ArgumentNullException(nameof(predicates));
-			_source = source;
+            FilterPolicy filterPolicy = FilterPolicy.ClearAndReplace)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (predicates == null) throw new ArgumentNullException(nameof(predicates));
+            _source = source;
             _predicates = predicates;
-		    _filterPolicy = filterPolicy;
-		}
-		
-		public IObservable<IChangeSet<T>> Run()
-		{
-			return Observable.Create<IChangeSet<T>>(observer =>
-			{
-				var locker = new object();
+            _filterPolicy = filterPolicy;
+        }
 
+        public IObservable<IChangeSet<T>> Run()
+        {
+            return Observable.Create<IChangeSet<T>>(observer =>
+            {
+                var allWithMatch = new List<ItemWithMatch>();
+                var all = new List<T>();
+                var filtered = new ChangeAwareList<T>();
+                var locker = new object();
 
-				//requery wehn controller either fires changed or requery event
-				var refresher = _predicates.Synchronize(locker)
-					.Select(predicate =>
-					{
-						Requery(predicate);
-						var changed = _filtered.CaptureChanges();
-					    return changed;
-					});
-				
-				var shared = _source.Synchronize(locker).Publish();
+                //requery wehn controller either fires changed or requery event
+                var refresher = _predicates.Synchronize(locker)
+                    .Select(predicate =>
+                    {
+                        Requery(predicate, allWithMatch, all, filtered);
+                        var changed = filtered.CaptureChanges();
+                        return changed;
+                    });
 
-				//take current filter state of all items
-			    IDisposable updateall;
+                var shared = _source.Synchronize(locker).Publish();
 
-			    if (_filterPolicy == FilterPolicy.ClearAndReplace)
-			    {
+                //take current filter state of all items
+                IDisposable updateall;
+
+                if (_filterPolicy == FilterPolicy.ClearAndReplace)
+                {
                     updateall = shared.Synchronize(locker)
-                                    .Subscribe(_all.Clone);
+                                      .Subscribe(all.Clone);
                 }
-			    else
-			    {
+                else
+                {
                     updateall = shared.Synchronize(locker)
-                                    .Transform(t => new ItemWithMatch(t, _predicate(t)))
-                                    .Subscribe(_allWithMatch.Clone);
+                                      .Transform(t => new ItemWithMatch(t, _predicate(t)))
+                                      .Subscribe(allWithMatch.Clone);
                 }
-                
-				//filter result list
-				var filter = shared.Synchronize(locker)
-									.Select(changes =>
-									{
-										_filtered.Filter(changes, _predicate);
-                                        var changed = _filtered.CaptureChanges();
+
+                //filter result list
+                var filter = shared.Synchronize(locker)
+                                    .Select(changes =>
+                                    {
+                                        filtered.Filter(changes, _predicate);
+                                        var changed = filtered.CaptureChanges();
                                         return changed;
                                     });
 
-				var subscriber = refresher.Merge(filter).NotEmpty().SubscribeSafe(observer);
+                var subscriber = refresher.Merge(filter).NotEmpty().SubscribeSafe(observer);
 
-				return new CompositeDisposable(updateall, subscriber, shared.Connect());
-			});
-		}
+                return new CompositeDisposable(updateall, subscriber, shared.Connect());
+            });
+        }
 
         //TODO: Need to account for re-evaluate (as it is not mutually excluse to clear and replace)
 
-		private void Requery(Func<T, bool> predicate)
-		{
-			_predicate = predicate;
+        private void Requery(Func<T, bool> predicate, List<ItemWithMatch> allWithMatch, List<T> all, ChangeAwareList<T> filtered)
+        {
+            _predicate = predicate;
 
-		    if (_filterPolicy == FilterPolicy.ClearAndReplace)
-		    {
-                _filtered.Clear();
-                _filtered.AddRange(_all.Where(_predicate));
+            if (_filterPolicy == FilterPolicy.ClearAndReplace)
+            {
+                filtered.Clear();
+                filtered.AddRange(all.Where(_predicate));
 
                 return;
-		    }
+            }
 
+            var newState = allWithMatch.Select(item =>
+            {
+                var match = _predicate(item.Item);
+                var wasMatch = item.IsMatch;
 
-			var newState = _allWithMatch.Select(item =>
-			{
-				var match = _predicate(item.Item);
-				var wasMatch = item.IsMatch;
+                //reflect filtered state
+                if (item.IsMatch != match) item.IsMatch = match;
 
-				//reflect filtered state
-				if (item.IsMatch != match) item.IsMatch = match;
+                return new
+                {
+                    Item = item,
+                    IsMatch = match,
+                    WasMatch = wasMatch
+                };
+            }).ToList();
 
-				return new
-				{
-					Item = item,
-					IsMatch = match,
-					WasMatch = wasMatch
-				};
-			}).ToList();
-
-			//reflect items which are no longer matched
-			var noLongerMatched = newState.Where(state => !state.IsMatch && state.WasMatch).Select(state => state.Item.Item);
-            _filtered.RemoveMany(noLongerMatched);
+            //reflect items which are no longer matched
+            var noLongerMatched = newState.Where(state => !state.IsMatch && state.WasMatch).Select(state => state.Item.Item);
+            filtered.RemoveMany(noLongerMatched);
 
             //reflect new matches in the list
             var newMatched = newState.Where(state => state.IsMatch && !state.WasMatch).Select(state => state.Item.Item);
-			_filtered.AddRange(newMatched);
-		}
+            filtered.AddRange(newMatched);
+        }
 
-		private class ItemWithMatch
-		{
-			public T Item { get; }
-			public bool IsMatch { get; set; }
+        private class ItemWithMatch
+        {
+            public T Item { get; }
+            public bool IsMatch { get; set; }
 
-			public ItemWithMatch(T item, bool isMatch)
-			{
-				Item = item;
-				IsMatch = isMatch;
-			}
-		}
+            public ItemWithMatch(T item, bool isMatch)
+            {
+                Item = item;
+                IsMatch = isMatch;
+            }
+        }
 
-	}
+    }
 }


### PR DESCRIPTION
If you subscribe twice to a stream which has a filter the change sets sent to the second subscriber will be incorrect.  This is because the MutableFilter class holds global state which will be mutated twice per input change set received.