### PR TITLE
Make sure that RemoveAt and RemoveRange have the same behavior on ChangeAwareList

### DIFF
--- a/DynamicData.Tests/ListFixtures/ChangeAwareListFixture.cs
+++ b/DynamicData.Tests/ListFixtures/ChangeAwareListFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using DynamicData.Internal;
 using DynamicData.Kernel;
 using NUnit.Framework;
@@ -205,6 +206,25 @@ namespace DynamicData.Tests.ListFixtures
 
             //assert collection
             Assert.AreEqual(0, _list.Count);
+        }
+
+        [Test]
+        public void ThrowWhenRemovingItemOutsideOfBoundaries()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _list.RemoveAt(0));
+        }
+
+        [Test]
+        public void ThrowWhenRemovingRangeThatBeginsOutsideOfBoundaries()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _list.RemoveRange(0, 1));
+        }
+
+        [Test]
+        public void ThrowWhenRemovingRangeThatFinishesOutsideOfBoundaries()
+        {
+            _list.Add(0);
+            Assert.Throws<ArgumentOutOfRangeException>(() => _list.RemoveRange(0, 2));
         }
 
     }

--- a/DynamicData/List/Internal/ChangeAwareList.cs
+++ b/DynamicData/List/Internal/ChangeAwareList.cs
@@ -58,6 +58,9 @@ namespace DynamicData.Internal
 
         public void RemoveRange(int index, int count)
         {
+            if (index >= _innerList.Count || index + count > _innerList.Count)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
             var toremove = _innerList.Skip(index).Take(count).ToList();
             if (toremove.Count == 0) return;
             var args = new Change<T>(ListChangeReason.RemoveRange, toremove, index);


### PR DESCRIPTION
Hi Roland,

I think that ChangeAwareList's `RemoveAt` and `RemoveRange` methods should have the same behavior when trying to remove items outside of the `_innerList` range. 
Currently when you call `RemoveAt` with an index that's outside of the list range you get a nice `ArgumentOutOfRangeException`. But when you call `RemoveRange` with a range that begins or finishes outside of the `_innerList` range you get nothing (since the implementation is based on `Skip` / `Take` Linq methods).

This PR has two commits : first with only the failing unit tests, second commit with the fix in `ChangeAwareList.cs`