### PR TITLE
Precompile expressions in WhenValueChanged and WhenPropertyChanged extension methods

### DIFF
--- a/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/DynamicData.Tests/DynamicData.Tests.csproj
@@ -194,6 +194,7 @@
     <Compile Include="ListFixtures\XOrFixture.cs" />
     <Compile Include="ListFixtures\_TestSubmittedExternally.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Utilities\NotifyPropertyChangedExFixture.cs" />
     <Compile Include="Utilities\SelectManyExtensions.cs" />
     <Compile Include="CacheFixtures\SourceCacheFixture.cs" />
     <Compile Include="Utilities\Timer.cs" />

--- a/DynamicData.Tests/Utilities/NotifyPropertyChangedExFixture.cs
+++ b/DynamicData.Tests/Utilities/NotifyPropertyChangedExFixture.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using DynamicData.Binding;
+using DynamicData.Tests.Domain;
+using NUnit.Framework;
+
+namespace DynamicData.Tests.Utilities
+{
+    public class NotifyPropertyChangedExFixture
+    {
+        [Test]
+        public void SubscribeToValueChangeForAllItemsInList([Values(true, false)] bool notifyOnInitialValue)
+        {
+            var lastAgeChange = -1;
+            var source = new SourceList<Person>();
+            source.Connect().WhenValueChanged(p => p.Age, notifyOnInitialValue).Subscribe(i => lastAgeChange = i);
+            var person = new Person("Name", 10);
+            var anotherPerson = new Person("AnotherName", 10);
+            source.Add(person);
+            source.Add(anotherPerson);
+
+            Assert.That(lastAgeChange, Is.EqualTo(notifyOnInitialValue ? 10 : -1));
+            person.Age = 12;
+            Assert.That(lastAgeChange, Is.EqualTo(12));
+            anotherPerson.Age = 13;
+            Assert.That(lastAgeChange, Is.EqualTo(13));
+        }
+
+        [Test]
+        public void SubscribeToValueChangedOnASingleItem([Values(true, false)] bool notifyOnInitialValue)
+        {
+            var age = -1;
+            var person = new Person("Name", 10);
+            person.WhenValueChanged(p => p.Age, notifyOnInitialValue).Subscribe(i => age = i);
+
+            Assert.That(age, Is.EqualTo(notifyOnInitialValue ? 10 : -1));
+            person.Age = 12;
+            Assert.That(age, Is.EqualTo(12));
+            person.Age = 13;
+            Assert.That(age, Is.EqualTo(13));
+        }
+
+        [Test]
+        public void SubscribeToPropertyChangeForAllItemsInList([Values(true, false)] bool notifyOnInitialValue)
+        {
+            var lastChange = new PropertyValue<Person, int>(null, -1);
+            var source = new SourceList<Person>();
+            source.Connect().WhenPropertyChanged(p => p.Age, notifyOnInitialValue).Subscribe(c => lastChange = c);
+            var person = new Person("Name", 10);
+            var anotherPerson = new Person("AnotherName", 10);
+            source.Add(person);
+            source.Add(anotherPerson);
+
+            if (notifyOnInitialValue)
+            {
+                Assert.That(lastChange.Sender, Is.EqualTo(anotherPerson));
+                Assert.That(lastChange.Value, Is.EqualTo(10));
+            }
+            else
+            {
+                Assert.That(lastChange.Sender, Is.Null);
+                Assert.That(lastChange.Value, Is.EqualTo(-1));
+            }
+
+            person.Age = 12;
+            Assert.That(lastChange.Sender, Is.EqualTo(person));
+            Assert.That(lastChange.Value, Is.EqualTo(12));
+            anotherPerson.Age = 13;
+            Assert.That(lastChange.Sender, Is.EqualTo(anotherPerson));
+            Assert.That(lastChange.Value, Is.EqualTo(13));
+        }
+
+        [Test]
+        public void SubscribeToProperyChangedOnASingleItem([Values(true, false)] bool notifyOnInitialValue)
+        {
+            var lastChange = new PropertyValue<Person, int>(null, -1);
+            var person = new Person("Name", 10);
+            person.WhenPropertyChanged(p => p.Age, notifyOnInitialValue).Subscribe(c => lastChange = c);
+
+            if (notifyOnInitialValue)
+            {
+                Assert.That(lastChange.Sender, Is.EqualTo(person));
+                Assert.That(lastChange.Value, Is.EqualTo(10));
+            }
+            else
+            {
+                Assert.That(lastChange.Sender, Is.Null);
+                Assert.That(lastChange.Value, Is.EqualTo(-1));
+            }
+            person.Age = 12;
+            Assert.That(lastChange.Sender, Is.EqualTo(person));
+            Assert.That(lastChange.Value, Is.EqualTo(12));
+            person.Age = 13;
+            Assert.That(lastChange.Sender, Is.EqualTo(person));
+            Assert.That(lastChange.Value, Is.EqualTo(13));
+        }
+    }
+}

--- a/DynamicData/Binding/NotifyPropertyChangedEx.cs
+++ b/DynamicData/Binding/NotifyPropertyChangedEx.cs
@@ -12,41 +12,67 @@ namespace DynamicData.Binding
     /// </summary>
     public static class NotifyPropertyChangedEx
     {
-        /// <summary>
-        /// Observes property changes for the specified property, starting with the current value
-        /// </summary>
-        /// <typeparam name="TObject">The type of the object.</typeparam>
-        /// <typeparam name="TValue">The type of the value.</typeparam>
-        /// <param name="source">The source.</param>
-        /// <param name="propertyAccessor">The property accessor.</param>
-        /// <param name="notifyOnInitialValue">if set to <c>true</c> [notify on initial value].</param>
-        /// <returns></returns>
-        /// <exception cref="System.ArgumentNullException">propertyAccessor</exception>
-        public static IObservable<PropertyValue<TObject, TValue>> WhenPropertyChanged<TObject, TValue>(
-            [NotNull] this TObject source,
+	    /// <summary>
+	    /// Observes property changes for the specified property, starting with the current value
+	    /// </summary>
+	    /// <typeparam name="TObject">The type of the object.</typeparam>
+	    /// <typeparam name="TValue">The type of the value.</typeparam>
+	    /// <param name="source">The source.</param>
+	    /// <param name="propertyAccessor">The property accessor.</param>
+	    /// <param name="notifyOnInitialValue">if set to <c>true</c> [notify on initial value].</param>
+	    /// <returns></returns>
+	    /// <exception cref="System.ArgumentNullException">propertyAccessor</exception>
+	    public static IObservable<PropertyValue<TObject, TValue>> WhenPropertyChanged<TObject, TValue>(
+	        [NotNull] this TObject source,
             Expression<Func<TObject, TValue>> propertyAccessor, bool notifyOnInitialValue = true)
             where TObject : INotifyPropertyChanged
         {
-            if (source == null) throw new ArgumentNullException(nameof(source));
-            if (propertyAccessor == null) throw new ArgumentNullException(nameof(propertyAccessor));
+	        if (source == null)
+	            throw new ArgumentNullException(nameof(source));
+	        if (propertyAccessor == null)
+	            throw new ArgumentNullException(nameof(propertyAccessor));
 
             var member = propertyAccessor.GetProperty();
             var accessor = propertyAccessor.Compile();
 
-            Func<PropertyValue<TObject, TValue>> factory = () => new PropertyValue<TObject, TValue>(source, accessor(source));
-
-            var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>
-                (
-                    handler => source.PropertyChanged += handler,
-                    handler => source.PropertyChanged -= handler
-                )
-                                            .Where(args => args.EventArgs.PropertyName == member.Name)
-                                            .Select(x => factory());
-
-            return !notifyOnInitialValue ? propertyChanged : propertyChanged.StartWith(factory());
-        }
+	        return WhenPropertyChanged(source, accessor, member.Name, notifyOnInitialValue);
+	    }
 
         /// <summary>
+	    /// Observes property changes for the specified property, starting with the current value
+	    /// </summary>
+	    /// <typeparam name="TObject">The type of the object.</typeparam>
+	    /// <typeparam name="TValue">The type of the value.</typeparam>
+	    /// <param name="source">The source.</param>
+	    /// <param name="propertyAccessor">The property accessor.</param>
+	    /// <param name="propertyName">The property name to observe.</param>
+	    /// <param name="notifyOnInitialValue">if set to <c>true</c> [notify on initial value].</param>
+	    /// <returns></returns>
+	    /// <exception cref="System.ArgumentNullException">propertyAccessor</exception>
+	    public static IObservable<PropertyValue<TObject, TValue>> WhenPropertyChanged<TObject, TValue>(
+	        [NotNull] this TObject source,
+	        Func<TObject, TValue> propertyAccessor, string propertyName, bool notifyOnInitialValue = true)
+	        where TObject : INotifyPropertyChanged
+	    {
+	        if (source == null)
+	            throw new ArgumentNullException(nameof(source));
+	        if (propertyAccessor == null)
+	            throw new ArgumentNullException(nameof(propertyAccessor));
+
+	        Func<PropertyValue<TObject, TValue>> factory = () => new PropertyValue<TObject, TValue>(source, propertyAccessor(source));
+
+	        var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>
+	            (
+	                handler => source.PropertyChanged += handler,
+	                handler => source.PropertyChanged -= handler
+	            )
+	                                        .Where(args => args.EventArgs.PropertyName == propertyName)
+	                                        .Select(x => factory());
+
+	        return !notifyOnInitialValue ? propertyChanged : propertyChanged.StartWith(factory());
+	    }
+
+	    /// <summary>
         /// Notifies when any any property on the object has changed
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
@@ -66,29 +92,26 @@ namespace DynamicData.Binding
                              .Select(x => source);
         }
 
-        /// <summary>
-        /// Observes property changes for the specified property, starting with the current value
-        /// </summary>
-        /// <typeparam name="TObject">The type of the object.</typeparam>
-        /// <typeparam name="TValue">The type of the value.</typeparam>
-        /// <param name="source">The source.</param>
-        /// <param name="propertyAccessor">The property accessor.</param>
-        /// <param name="notifyOnInitialValue">if set to <c>true</c> [notify on initial value].</param>
-        /// <returns></returns>
-        /// <exception cref="System.ArgumentNullException">
-        /// </exception>
-        public static IObservable<TValue> WhenValueChanged<TObject, TValue>([NotNull] this TObject source, Expression<Func<TObject, TValue>> propertyAccessor, bool notifyOnInitialValue = true)
-            where TObject : INotifyPropertyChanged
-        {
+	    /// <summary>
+	    /// Observes property changes for the specified property, starting with the current value
+	    /// </summary>
+	    /// <typeparam name="TObject">The type of the object.</typeparam>
+	    /// <typeparam name="TValue">The type of the value.</typeparam>
+	    /// <param name="source">The source.</param>
+	    /// <param name="propertyAccessor">The property accessor.</param>
+	    /// <param name="notifyOnInitialValue">if set to <c>true</c> [notify on initial value].</param>
+	    /// <returns></returns>
+	    /// <exception cref="System.ArgumentNullException">
+	    /// </exception>
+	    public static IObservable<TValue> WhenValueChanged<TObject, TValue>([NotNull] this TObject source, Expression<Func<TObject, TValue>> propertyAccessor, bool notifyOnInitialValue = true)
+	        where TObject : INotifyPropertyChanged
+	    {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (propertyAccessor == null) throw new ArgumentNullException(nameof(propertyAccessor));
 
             var member = propertyAccessor.GetProperty();
             var accessor = propertyAccessor.Compile();
-
-            Func<PropertyValue<TObject, TValue>> factory =
-                () => new PropertyValue<TObject, TValue>(source, accessor(source));
-
+            
             var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>
                 (
                     handler => source.PropertyChanged += handler,
@@ -98,6 +121,36 @@ namespace DynamicData.Binding
                                             .Select(x => accessor(source));
 
             return !notifyOnInitialValue ? propertyChanged : propertyChanged.StartWith(accessor(source));
+        }
+
+        /// <summary>
+        /// Observes property changes for the specified property, starting with the current value
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="propertyAccessor">The property accessor.</param>
+        /// <param name="propertyName">The property name to observe.</param>
+        /// <param name="notifyOnInitialValue">if set to <c>true</c> [notify on initial value].</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// </exception>
+        public static IObservable<TValue> WhenValueChanged<TObject, TValue>([NotNull] this TObject source, Func<TObject, TValue> propertyAccessor, string propertyName, bool notifyOnInitialValue = true)
+            where TObject : INotifyPropertyChanged
+        {
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+            if (propertyAccessor == null)
+                throw new ArgumentNullException(nameof(propertyAccessor));
+
+            var propertyChanged = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>
+                (
+                    handler => source.PropertyChanged += handler,
+                    handler => source.PropertyChanged -= handler
+                ).Where(args => args.EventArgs.PropertyName == propertyName)
+                                            .Select(x => propertyAccessor(source));
+
+            return !notifyOnInitialValue ? propertyChanged : propertyChanged.StartWith(propertyAccessor(source));
         }
 
         /// <summary>
@@ -133,7 +186,7 @@ namespace DynamicData.Binding
                              .Select(x => x.EventArgs.PropertyName);
         }
 
-        private static PropertyInfo GetProperty<TObject, TProperty>(this Expression<Func<TObject, TProperty>> expression)
+	    internal static PropertyInfo GetProperty<TObject, TProperty>(this Expression<Func<TObject, TProperty>> expression)
         {
             var property = GetMember(expression) as PropertyInfo;
             if (property == null)

--- a/DynamicData/List/ObservableListEx.cs
+++ b/DynamicData/List/ObservableListEx.cs
@@ -697,7 +697,10 @@ namespace DynamicData
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (propertyAccessor == null) throw new ArgumentNullException(nameof(propertyAccessor));
 
-            return source.MergeMany(t => t.WhenValueChanged(propertyAccessor, notifyOnInitialValue));
+            var member = propertyAccessor.GetProperty();
+            var accessor = propertyAccessor.Compile();
+
+            return source.MergeMany(t => t.WhenValueChanged(accessor, member.Name, notifyOnInitialValue));
         }
 
         /// <summary>
@@ -718,9 +721,11 @@ namespace DynamicData
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (propertyAccessor == null) throw new ArgumentNullException(nameof(propertyAccessor));
 
-            return source.MergeMany(t => t.WhenPropertyChanged(propertyAccessor, notifyOnInitialValue));
-        }
+            var member = propertyAccessor.GetProperty();
+            var accessor = propertyAccessor.Compile();
 
+            return source.MergeMany(t => t.WhenPropertyChanged(accessor, member.Name, notifyOnInitialValue));
+        }
         /// <summary>
         /// Watches each item in the collection and notifies when any of them has changed
         /// </summary>


### PR DESCRIPTION
Hi,

Minor perf improvment on `.WhenPropertyChanged()` and `.WhenValueChanged()` extension methods :
It allows to compile the given expression only once and give the result to extension methods on INotifyPropertyChanged objects instead of compiling the expression for each object.