### PR TITLE
Add more info in grouping error messages.

### DIFF
--- a/DynamicData/Cache/Internal/Grouper.cs
+++ b/DynamicData/Cache/Internal/Grouper.cs
@@ -123,11 +123,15 @@ namespace DynamicData.Internal
                             {
                                 updater.AddOrUpdate(current.Item, current.Key);
 
-                                //check whether the previous item was in a different group. If so remove from old group
-                                var previous = _itemCache.Lookup(current.Key)
-                                                         .ValueOrThrow(() => new MissingKeyException("{0} is missing from previous value".FormatWith(current.Key)));
+                                    //check whether the previous item was in a different group. If so remove from old group
+                                    var previous = _itemCache.Lookup(current.Key)
+                                        .ValueOrThrow(
+                                            () =>
+                                                new MissingKeyException("{0} is missing from previous value on update. Object type {1}, Key type {2}, Group key type {3}"
+                                                    .FormatWith(current.Key, typeof(TObject), typeof(TKey),
+                                                        typeof(TGroupKey))));
 
-                                if (previous.GroupKey.Equals(current.GroupKey)) return;
+                                    if (previous.GroupKey.Equals(current.GroupKey)) return;
 
                                 _groupCache.Lookup(previous.GroupKey)
                                            .IfHasValue(g =>
@@ -152,7 +156,11 @@ namespace DynamicData.Internal
                                 {
                                     //this has been removed due to an underlying evaluate resulting in a remove
                                     var previousGroupKey = _itemCache.Lookup(current.Key)
-                                                                     .ValueOrThrow(() => new MissingKeyException("{0} is missing from previous value".FormatWith(current.Key)))
+                                        .ValueOrThrow(
+                                            () =>
+                                                new MissingKeyException("{0} is missing from previous value on remove. Object type {1}, Key type {2}, Group key type {3}"
+                                                    .FormatWith(current.Key, typeof(TObject), typeof(TKey),
+                                                        typeof(TGroupKey))))
                                                                      .GroupKey;
 
                                     _groupCache.Lookup(previousGroupKey)


### PR DESCRIPTION
Makes identification of cache in error easier when you have multiple cache types in play.