### PR TITLE
Make RefCount operators thread-safe

### DIFF
--- a/DynamicData.Tests/CacheFixtures/RefCountFixture.cs
+++ b/DynamicData.Tests/CacheFixtures/RefCountFixture.cs
@@ -2,6 +2,8 @@
 using DynamicData.Tests.Domain;
 using NUnit.Framework;
 using System;
+using System.Threading.Tasks;
+using System.Linq;
 
 namespace DynamicData.Tests.CacheFixtures
 {
@@ -72,6 +74,27 @@ namespace DynamicData.Tests.CacheFixtures
 
             Assert.AreEqual(2, created);
             Assert.AreEqual(2, disposals);
+        }
+
+        // This test is probabilistic, it could be cool to be able to prove RefCount's thread-safety
+        // more accurately but I don't think that there is an easy way to do this.
+        // At least this test can catch some bugs in the old implementation.
+        [Test]
+        public async Task IsHopefullyThreadSafe()
+        {
+            var refCount = _source.Connect().RefCount();
+
+            await Task.WhenAll(Enumerable.Range(0, 100).Select(_ =>
+            {
+                return Task.Run(() =>
+                {
+                    for (int i = 0; i < 1000; ++i)
+                    {
+                        var subscription = refCount.Subscribe();
+                        subscription.Dispose();
+                    }
+                });
+            }));
         }
     }
 }

--- a/DynamicData.Tests/CacheFixtures/RefCountFixture.cs
+++ b/DynamicData.Tests/CacheFixtures/RefCountFixture.cs
@@ -85,16 +85,14 @@ namespace DynamicData.Tests.CacheFixtures
             var refCount = _source.Connect().RefCount();
 
             await Task.WhenAll(Enumerable.Range(0, 100).Select(_ =>
-            {
-                return Task.Run(() =>
+                Task.Run(() =>
                 {
                     for (int i = 0; i < 1000; ++i)
                     {
                         var subscription = refCount.Subscribe();
                         subscription.Dispose();
                     }
-                });
-            }));
+                })));
         }
     }
 }

--- a/DynamicData.Tests/ListFixtures/RefCountFixture.cs
+++ b/DynamicData.Tests/ListFixtures/RefCountFixture.cs
@@ -2,6 +2,8 @@ using System;
 using System.Reactive.Linq;
 using DynamicData.Tests.Domain;
 using NUnit.Framework;
+using System.Threading.Tasks;
+using System.Linq;
 
 namespace DynamicData.Tests.ListFixtures
 {
@@ -72,6 +74,27 @@ namespace DynamicData.Tests.ListFixtures
 
             Assert.AreEqual(2, created);
             Assert.AreEqual(2, disposals);
+        }
+
+        // This test is probabilistic, it could be cool to be able to prove RefCount's thread-safety
+        // more accurately but I don't think that there is an easy way to do this.
+        // At least this test can catch some bugs in the old implementation.
+        [Test]
+        public async Task IsHopefullyThreadSafe()
+        {
+            var refCount = _source.Connect().RefCount();
+
+            await Task.WhenAll(Enumerable.Range(0, 100).Select(_ =>
+            {
+                return Task.Run(() =>
+                {
+                    for (int i = 0; i < 1000; ++i)
+                    {
+                        var subscription = refCount.Subscribe();
+                        subscription.Dispose();
+                    }
+                });
+            }));
         }
     }
 }

--- a/DynamicData.Tests/ListFixtures/RefCountFixture.cs
+++ b/DynamicData.Tests/ListFixtures/RefCountFixture.cs
@@ -85,16 +85,14 @@ namespace DynamicData.Tests.ListFixtures
             var refCount = _source.Connect().RefCount();
 
             await Task.WhenAll(Enumerable.Range(0, 100).Select(_ =>
-            {
-                return Task.Run(() =>
+                Task.Run(() =>
                 {
                     for (int i = 0; i < 1000; ++i)
                     {
                         var subscription = refCount.Subscribe();
                         subscription.Dispose();
                     }
-                });
-            }));
+                })));
         }
     }
 }


### PR DESCRIPTION
Hi, @RolandPheasant!
I was very curious about DynamicData internals and started to read some code. I found that `RefCount` operator is not thread-safe and I decided to give it a spin :smile:
I've also added a probablistic test to check thread-safety (you can run it and see that the previous implementation throws `NullReferenceException` almost everytime).
It's unclear to me how to test it deterministically.
Though I was trying hard to prove it as strictly as I could.
I'm still unsure if I should write this informal "proof" alongside the actual code or in the method doc-string.
Regardless of the actual placement I will try to do it tomorrow. Until when I will be happy to hear any questions or another feedback in this PR.