### PR TITLE
Add overload for AddOrUpdate with IEqualityComparer<T>

### DIFF
--- a/DynamicData/Cache/ISourceUpdater.cs
+++ b/DynamicData/Cache/ISourceUpdater.cs
@@ -35,6 +35,13 @@ namespace DynamicData
         void AddOrUpdate(TObject item);
 
         /// <summary>
+        /// Adds or update the item using a comparer 
+        /// </summary>
+        /// <param name="item">The item.</param>
+        /// <param name="comparer">The comparer</param>
+        void AddOrUpdate(TObject item, IEqualityComparer<TObject> comparer);
+
+        /// <summary>
         /// Evaluates the specified items.
         /// </summary>
         /// <param name="items">The items.</param>

--- a/DynamicData/Cache/Internal/CacheUpdater.cs
+++ b/DynamicData/Cache/Internal/CacheUpdater.cs
@@ -54,6 +54,23 @@ namespace DynamicData.Cache.Internal
             _cache.AddOrUpdate(item, key);
         }
 
+        public void AddOrUpdate(TObject item, IEqualityComparer<TObject> comparer)
+        {
+            if (_keySelector == null)
+                throw new KeySelectorException("A key selector must be specified");
+
+            var key = _keySelector.GetKey(item);
+            var oldItem = _cache.Lookup(key);
+            if (oldItem.HasValue)
+            {
+                if (comparer.Equals(oldItem.Value, item))
+                    return;
+                _cache.AddOrUpdate(item, key);
+                return;
+            }
+            _cache.AddOrUpdate(item, key);
+        }
+
         public TKey GetKey(TObject item)
         {
             if (_keySelector == null)


### PR DESCRIPTION
This PR adds an overload for AddOrUpdate with an IEqualityComparer<T>.
If the item already exists in the cache, it is run by the comparer to see if a update to the item is necessary