### PR TITLE
Implement IExtendedList

### DIFF
--- a/DynamicData.Tests/ListFixtures/CloneChangesFixture.cs
+++ b/DynamicData.Tests/ListFixtures/CloneChangesFixture.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using DynamicData.Kernel;
 using DynamicData.List.Internal;
 using NUnit.Framework;
+using System.Collections.ObjectModel;
 
 namespace DynamicData.Tests.ListFixtures
 {
@@ -162,6 +163,27 @@ namespace DynamicData.Tests.ListFixtures
             var changes = _source.CaptureChanges();
             _clone.Clone(changes);
             CollectionAssert.AreEqual(_source, _clone);
+        }
+
+        [Test]
+        public void MovedItemInObservableCollectionIsMoved()
+        {
+            _source.AddRange(Enumerable.Range(1, 10));
+            _source.Move(1, 2);
+
+            var clone = new ObservableCollection<int>();
+            var changes = _source.CaptureChanges();
+            var itemMoved = false;
+
+            clone.CollectionChanged += (s, e) =>
+            {
+                if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Move)
+                    itemMoved = true;
+            };
+
+            clone.Clone(changes);
+
+            Assert.True(itemMoved);
         }
     }
 }

--- a/DynamicData/Binding/ObservableCollectionExtended.cs
+++ b/DynamicData/Binding/ObservableCollectionExtended.cs
@@ -11,7 +11,7 @@ namespace DynamicData.Binding
     /// An override of observable collection which allows the suspension of notifications
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class ObservableCollectionExtended<T> : ObservableCollection<T>, IObservableCollection<T>
+    public class ObservableCollectionExtended<T> : ObservableCollection<T>, IObservableCollection<T>, IExtendedList<T>
     {
         #region Construction
 
@@ -118,5 +118,25 @@ namespace DynamicData.Binding
             foreach (var item in items)
                 Add(item);
         }
+
+        #region Implementation of IExtendedList
+        public void AddRange(IEnumerable<T> collection)
+        {
+            foreach (var item in collection)
+                Add(item);
+        }
+
+        public void InsertRange(IEnumerable<T> collection, int index)
+        {
+            foreach (var item in collection)
+                InsertItem(index++, item);
+        }
+
+        public void RemoveRange(int index, int count)
+        {
+            for (var i = 0; i < count; i++)
+                RemoveAt(index);
+        }
+        #endregion
     }
 }

--- a/DynamicData/List/ListEx.cs
+++ b/DynamicData/List/ListEx.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DynamicData.Annotations;
 using DynamicData.Kernel;
+using System.Collections.ObjectModel;
 
 // ReSharper disable once CheckNamespace
 namespace DynamicData
@@ -207,14 +208,19 @@ namespace DynamicData
                             if (!hasIndex)
                                 throw new UnspecifiedIndexException("Cannot move as an index was not specified");
 
-                            var collection = source as IExtendedList<T>;
-                            if (collection != null)
+                            var extendedList = source as IExtendedList<T>;
+                            var observableCollection = source as ObservableCollection<T>;
+                            if (extendedList != null)
                             {
-                                collection.Move(change.PreviousIndex, change.CurrentIndex);
+                                extendedList.Move(change.PreviousIndex, change.CurrentIndex);
+                            }
+                            else if (observableCollection != null)
+                            {
+                                observableCollection.Move(change.PreviousIndex, change.CurrentIndex);
                             }
                             else
                             {
-                                //check this works whatever the index is 
+                                //check this works whatever the index is
                                 source.RemoveAt(change.PreviousIndex);
                                 source.Insert(change.CurrentIndex, change.Current);
                             }
@@ -226,7 +232,7 @@ namespace DynamicData
 
         /// <summary>
         /// Clears the collection if the number of items in the range is the same as the source collection. Otherwise a  remove many operation is applied.
-        /// 
+        ///
         /// NB: This is because an observable change set may be a composite of multiple change sets in which case if one of them has clear operation applied it should not clear the entire result.
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -276,7 +282,7 @@ namespace DynamicData
 
         /// <summary>
         /// Performs a binary search on the specified collection.
-        /// 
+        ///
         /// Thanks to http://stackoverflow.com/questions/967047/how-to-perform-a-binary-search-on-ilistt
         /// </summary>
         /// <typeparam name="TItem">The type of the item.</typeparam>
@@ -476,7 +482,7 @@ namespace DynamicData
             /*
                 This may seem OTT but for large sets of data where there are many removes scattered
                 across the source collection IndexOf lookups can result in very slow updates
-                (especially for subsequent operators) 
+                (especially for subsequent operators)
             */
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (itemsToRemove == null) throw new ArgumentNullException(nameof(itemsToRemove));
@@ -489,7 +495,7 @@ namespace DynamicData
                                  .ToArray();
 
             //if there are duplicates, it could be that an item exists in the
-            //source collection more than once - in that case the fast remove 
+            //source collection more than once - in that case the fast remove
             //would remove each instance
             var hasDuplicates = toRemove.Duplicates(t => t.Item).Any();
 


### PR DESCRIPTION
Having `ObservableCollectionExtended<T>` implement `IExtendedList<T>` ensures the `ListEx.Clone` method invokes the `Move` method.

An alternative solution I considered was introducing a new interface called something like `IMove`, and derive both `IExtendedList<T>` as well as `IObservableCollection<T>` from that, so that `ObservableCollectionExtended` doesn't have to also implement the `AddRange`, `RemoveRange` and `InsertRange` methods. But then again, maybe it's not a bad thing it supports thee operations as well.

Let me know if you have any other suggestions, I'm happy to make changes.