### PR TITLE
fix: restrict system.reactive to 3.1.1 as min but never 4.x series 

### DIFF
--- a/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
+++ b/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="8.0.0-alpha0057" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="reactiveui" Version="8.0.0-alpha0069" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
 
@@ -22,7 +22,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
   </ItemGroup>
 
 </Project>

--- a/DynamicData.ReactiveUI/DynamicData.ReactiveUI.csproj
+++ b/DynamicData.ReactiveUI/DynamicData.ReactiveUI.csproj
@@ -7,7 +7,7 @@
     <ProjectReference Include="..\DynamicData\DynamicData.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="8.0.0-alpha0057" />
+    <PackageReference Include="reactiveui" Version="8.0.0-alpha0069" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/DynamicData.Tests/DynamicData.Tests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,6 +27,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
   </ItemGroup>
 </Project>

--- a/DynamicData/DynamicData.csproj
+++ b/DynamicData/DynamicData.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46'">


### PR DESCRIPTION
Refer to https://github.com/reactiveui/ReactiveUI/pull/1451 for backstory. 

**What is the new behavior (if this is a feature change)?**

Fixes https://github.com/reactiveui/ReactiveUI/pull/1413 by bypassing NuGet issue @ https://github.com/NuGet/Home/issues/5751

**Other information**:

System.Reactive v4.x and NuGet.exe needs more time to mature. We can remove these restrictions as a point release at a later point in time. Dynamic data is currently using `3.1.1` as min but is not clamped @RolandPheasant I strongly recommend that you do the same changes. Similar changes will be applied to Akavache, Refit, Punchclock, etc.
