### PR TITLE
Allow for a custom filter with `TransformToTree`

### DIFF
--- a/DynamicData/Cache/Internal/TreeBuilder.cs
+++ b/DynamicData/Cache/Internal/TreeBuilder.cs
@@ -23,7 +23,7 @@ namespace DynamicData.Cache.Internal
             _predicateChanged = predicateChanged ?? Observable.Return(DefaultPredicate);
         }
 
-        internal static Func<Node<TObject, TKey>, bool> DefaultPredicate => node => node.IsRoot;
+        internal static readonly Func<Node<TObject, TKey>, bool> DefaultPredicate = node => node.IsRoot;
 
         public IObservable<IChangeSet<Node<TObject, TKey>, TKey>> Run()
         {
@@ -170,7 +170,7 @@ namespace DynamicData.Cache.Internal
                     parentSetter.Dispose();
                     allData.Dispose();
                     allNodes.Dispose();
-                    refilterObservable.Dispose();
+                    refilterObservable.OnCompleted();
                 });
             });
         }

--- a/DynamicData/Cache/ObservableCacheEx.cs
+++ b/DynamicData/Cache/ObservableCacheEx.cs
@@ -2717,14 +2717,16 @@ namespace DynamicData
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <param name="source">The source.</param>
         /// <param name="pivotOn">The pivot on.</param>
+        /// <param name="predicateChanged">Observable to change the underlying predicate.</param>
         /// <returns></returns>
         public static IObservable<IChangeSet<Node<TObject, TKey>, TKey>> TransformToTree<TObject, TKey>([NotNull] this IObservable<IChangeSet<TObject, TKey>> source,
-                                                                                                        [NotNull] Func<TObject, TKey> pivotOn)
+                                                                                                        [NotNull] Func<TObject, TKey> pivotOn,
+                                                                                                        IObservable<Func<Node<TObject, TKey>, bool>> predicateChanged = null)
             where TObject : class
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
             if (pivotOn == null) throw new ArgumentNullException(nameof(pivotOn));
-            return new TreeBuilder<TObject, TKey>(source, pivotOn).Run();
+            return new TreeBuilder<TObject, TKey>(source, pivotOn, predicateChanged).Run();
         }
 
 


### PR DESCRIPTION
I'm finding the `TransformToTree` operator to be extremely useful for my project. However, I'm finding that I'd like to be able to filter the resulting cache in different ways -- for instance, maybe to "flatten" the cache, or cache nodes at a specified level rather than root.