### PR TITLE
new operator to convert sorting operations resulting in moves into re…

### DIFF
--- a/DynamicData.ReactiveUI.Tests/Fixtures/BindSortedChangeSetFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/BindSortedChangeSetFixture.cs
@@ -133,5 +133,49 @@ namespace DynamicData.ReactiveUI.Tests.Fixtures
             resetinvoked.Should().BeFalse();
         }
 
+	    [Fact]
+	    public void TreatMovesAsRemoveAdd()
+	    {
+		    var cache = new SourceCache<Person, string>(p => p.Name);
+
+		    var people = Enumerable.Range(0,10).Select(age => new Person("Person" + age, age)).ToList();
+		    var importantGuy = people.First();
+		    cache.AddOrUpdate(people);
+
+		    ISortedChangeSet<Person, string> latestSetWithoutMoves = null;
+		    ISortedChangeSet<Person, string> latestSetWithMoves = null;
+
+		    var boundList1 = new ReactiveList<Person>();
+		    var boundList2 = new ReactiveList<Person>();
+
+
+		    using (cache.Connect()
+			    .AutoRefresh(p => p.Age)
+			    .Sort(SortExpressionComparer<Person>.Ascending(p => p.Age))
+			    .TreatMovesAsRemoveAdd()
+			    .Bind(boundList1)
+			    .Subscribe(set => latestSetWithoutMoves = set))
+
+		    using (cache.Connect()
+			    .AutoRefresh(p => p.Age)
+			    .Sort(SortExpressionComparer<Person>.Ascending(p => p.Age))
+			    .Bind(boundList2)
+			    .Subscribe(set => latestSetWithMoves = set))
+		    {
+
+			    importantGuy.Age = importantGuy.Age + 200;
+
+		
+			    latestSetWithoutMoves.Removes.Should().Be(1);
+			    latestSetWithoutMoves.Adds.Should().Be(1);
+			    latestSetWithoutMoves.Moves.Should().Be(0);
+			    latestSetWithoutMoves.Updates.Should().Be(0);
+
+			    latestSetWithMoves.Moves.Should().Be(1);
+			    latestSetWithMoves.Updates.Should().Be(0);
+			    latestSetWithMoves.Removes.Should().Be(0);
+			    latestSetWithMoves.Adds.Should().Be(0);
+		    }
+	    }
     }
 }


### PR DESCRIPTION
Some UI list controls are not able to cope with Moves and only understand Adds+ Removes. (see UWP ListView, for example).
so in introduced a new extension method on 
`IObservable<ISortedChangeSet<TObject, TKey>> `
called
`TreatMovesAsRemoveAdd`

in the wiki on the sorting page maybe we need to give people a hint as to that this operator exists and when to use it...