### PR TITLE
Changes to allow compilation on VS 7.5+ for Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -295,3 +295,5 @@ __pycache__/
 
 # End of https://www.gitignore.io/api/visualstudio
 DynamicData/project.lock.json
+DynamicData/.DS_Store
+.DS_Store

--- a/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
+++ b/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
+++ b/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
@@ -4,6 +4,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Copyright>Copyright Roland Pheasant 2011-2018</Copyright>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\DynamicData.ReactiveUI\DynamicData.ReactiveUI.csproj" />
     <ProjectReference Include="..\DynamicData\DynamicData.csproj" />

--- a/DynamicData.Tests/Cache/SuppressableSourceCacheFixture.cs
+++ b/DynamicData.Tests/Cache/SuppressableSourceCacheFixture.cs
@@ -49,5 +49,32 @@ namespace DynamicData.Tests.Cache
 
             0.Should().Be(_result.Data.Count);
         }
+
+        [Fact]
+        public void EnableDisableSuppressions()
+        {
+            using (var inner = _subjectUnderTest.SuppressNotifications())
+            {
+                inner.Edit(innerCache =>
+                {
+                    innerCache.AddOrUpdate("first");
+                });
+            }
+
+            _subjectUnderTest.Edit(innerCache =>
+            {
+                innerCache.AddOrUpdate("second");
+            });
+
+            using (var inner = _subjectUnderTest.SuppressNotifications())
+            {
+                inner.Edit(innerCache =>
+                {
+                    innerCache.AddOrUpdate("third");
+                });
+            }
+
+            1.Should().Be(_result.Data.Count);
+        }
     }
 }

--- a/DynamicData.Tests/Cache/SuppressableSourceCacheFixture.cs
+++ b/DynamicData.Tests/Cache/SuppressableSourceCacheFixture.cs
@@ -22,7 +22,7 @@ namespace DynamicData.Tests.Cache
         private readonly ChangeSetAggregator<string, string> _result;
 
         [Fact]
-        public void CHangesNotSuppressed()
+        public void ChangesNotSuppressed()
         {
             _subjectUnderTest.Edit(innerCache =>
             {

--- a/DynamicData.Tests/Cache/SuppressableSourceCacheFixture.cs
+++ b/DynamicData.Tests/Cache/SuppressableSourceCacheFixture.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using DynamicData.Cache;
+using FluentAssertions;
+using Xunit;
+
+namespace DynamicData.Tests.Cache
+{
+    public class SuppressableSourceCacheFixture : IDisposable
+    {
+        public SuppressableSourceCacheFixture()
+        {
+            _subjectUnderTest = new SourceCache<string, string>(x => x).WithNotificationSuppressionSupport();
+            _result = _subjectUnderTest.Connect().AsAggregator();
+        }
+
+        public void Dispose()
+        {
+            _subjectUnderTest?.Dispose();
+        }
+
+        private readonly ISuppressableSourceCache<string, string> _subjectUnderTest;
+        private readonly ChangeSetAggregator<string, string> _result;
+
+        [Fact]
+        public void CHangesNotSuppressed()
+        {
+            _subjectUnderTest.Edit(innerCache =>
+            {
+                innerCache.AddOrUpdate("first");
+                innerCache.AddOrUpdate("second");
+                innerCache.AddOrUpdate("third");
+            });
+
+            3.Should().Be(_result.Data.Count);
+        }
+
+        [Fact]
+        public void SuppressesNotification()
+        {
+            using (_subjectUnderTest.SuppressNotifications())
+            {
+                _subjectUnderTest.Edit(innerCache =>
+                {
+                    innerCache.AddOrUpdate("first");
+                    innerCache.AddOrUpdate("second");
+                    innerCache.AddOrUpdate("third");
+                });
+            }
+
+            0.Should().Be(_result.Data.Count);
+        }
+    }
+}

--- a/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/DynamicData.Tests/DynamicData.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   
@@ -8,7 +8,7 @@
     <Copyright>Copyright Roland Pheasant 2011-2018</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net452'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>P_LINQ</DefineConstants>
   </PropertyGroup>
 

--- a/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/DynamicData.Tests/DynamicData.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp1.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   

--- a/DynamicData/Cache/SuppressableSourceCache.cs
+++ b/DynamicData/Cache/SuppressableSourceCache.cs
@@ -9,7 +9,7 @@ namespace DynamicData.Cache
     {
         public static ISuppressableSourceCache<TObject, TKey> WithNotificationSuppressionSupport<TObject, TKey>(this SourceCache<TObject, TKey> self)
         {
-            return new SurppressableSourceCache<TObject, TKey>(self);
+            return new SuppressableSourceCache<TObject, TKey>(self);
         }
     }
 
@@ -18,12 +18,12 @@ namespace DynamicData.Cache
         ISourceCache<TObject, TKey> SuppressNotifications();
     }
 
-    internal class SurppressableSourceCache<TObject, TKey> : ISuppressableSourceCache<TObject, TKey>
+    internal class SuppressableSourceCache<TObject, TKey> : ISuppressableSourceCache<TObject, TKey>
     {
         private readonly ISourceCache<TObject, TKey> _target;
         private volatile bool _suppressed;
 
-        internal SurppressableSourceCache(ISourceCache<TObject, TKey> target)
+        internal SuppressableSourceCache(ISourceCache<TObject, TKey> target)
         {
             _target = target ?? throw new ArgumentNullException(nameof(target));
         }

--- a/DynamicData/Cache/SuppressableSourceCache.cs
+++ b/DynamicData/Cache/SuppressableSourceCache.cs
@@ -5,7 +5,7 @@ using DynamicData.Kernel;
 
 namespace DynamicData.Cache
 {
-    public static class SourceCacheSupressableExtensions
+    public static class SourceCacheSuppressableExtensions
     {
         public static ISuppressableSourceCache<TObject, TKey> WithNotificationSuppressionSupport<TObject, TKey>(this SourceCache<TObject, TKey> self)
         {

--- a/DynamicData/Cache/SurppressableSourceCache.cs
+++ b/DynamicData/Cache/SurppressableSourceCache.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using DynamicData.Kernel;
+
+namespace DynamicData.Cache
+{
+    public static class SourceCacheSupressableExtensions
+    {
+        public static ISuppressableSourceCache<TObject, TKey> WithNotificationSuppressionSupport<TObject, TKey>(this SourceCache<TObject, TKey> self)
+        {
+            return new SurppressableSourceCache<TObject, TKey>(self);
+        }
+    }
+
+    public interface ISuppressableSourceCache<TObject, TKey> : ISourceCache<TObject, TKey>
+    {
+        ISourceCache<TObject, TKey> SuppressNotifications();
+    }
+
+    internal class SurppressableSourceCache<TObject, TKey> : ISuppressableSourceCache<TObject, TKey>
+    {
+        private readonly ISourceCache<TObject, TKey> _target;
+        private volatile bool _suppressed;
+
+        internal SurppressableSourceCache(ISourceCache<TObject, TKey> target)
+        {
+            _target = target ?? throw new ArgumentNullException(nameof(target));
+        }
+
+        public IObservable<Change<TObject, TKey>> Watch(TKey key)
+        {
+            return _target.Watch(key).Where(_ => !_suppressed);
+        }
+
+        public IObservable<IChangeSet<TObject, TKey>> Connect(Func<TObject, bool> predicate = null)
+        {
+            return _target.Connect().Where(_ => !_suppressed);
+        }
+
+        public IObservable<int> CountChanged
+        {
+            get { return _target.CountChanged.Where(_ => !_suppressed); }
+        }
+
+        public void Edit(Action<ISourceUpdater<TObject, TKey>> updateAction)
+        {
+            _target.Edit(updateAction);
+        }
+
+        public void Dispose()
+        {
+            if (_suppressed)
+            {
+                _suppressed = false;
+                return;
+            }
+
+            _target.Dispose();
+        }
+
+        public IEnumerable<TKey> Keys => _target.Keys;
+
+        public IEnumerable<TObject> Items => _target.Items;
+
+        public IEnumerable<KeyValuePair<TKey, TObject>> KeyValues => _target.KeyValues;
+
+        public Optional<TObject> Lookup(TKey key)
+        {
+            return _target.Lookup(key);
+        }
+
+        public int Count => _target.Count;
+
+        public void OnCompleted()
+        {
+            _target.OnCompleted();
+        }
+
+        public void OnError(Exception exception)
+        {
+            _target.OnError(exception);
+        }
+
+        public ISourceCache<TObject, TKey> SuppressNotifications()
+        {
+            _suppressed = true;
+            return this;
+        }
+    }
+}

--- a/DynamicData/DynamicData.csproj
+++ b/DynamicData/DynamicData.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.1;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.1;net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 

--- a/DynamicData/DynamicData.csproj
+++ b/DynamicData/DynamicData.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.1;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -8,7 +8,7 @@
     <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>P_LINQ</DefineConstants>
   </PropertyGroup>
 

--- a/DynamicData/DynamicData.csproj
+++ b/DynamicData/DynamicData.csproj
@@ -8,6 +8,10 @@
     <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="DynamicData.csproj" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>P_LINQ</DefineConstants>
   </PropertyGroup>

--- a/DynamicData/DynamicData.csproj
+++ b/DynamicData/DynamicData.csproj
@@ -8,10 +8,6 @@
     <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="DynamicData.csproj" />
-  </ItemGroup>
-
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>P_LINQ</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Reordering to put netstandard2.0 at the front of the target frameowkr list. This allows compilation and test execution to succeed on Visual Studio for ac (v7.5+) as VS for Mac picks the first target framework in the list to target currently. This fools it into picking netstandard2.0.

Also adjusted .gitignore to remove annoying OSX artifacts.

### Note in the DD.Test.csproj, does the 452 need replacing with 461 versus just removing?