### PR TITLE
Avoid unnecessary tolist calls (performance optimization)

### DIFF
--- a/DynamicData/Cache/Internal/KeyValueCollection.cs
+++ b/DynamicData/Cache/Internal/KeyValueCollection.cs
@@ -2,22 +2,19 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using DynamicData.Kernel;
 
 namespace DynamicData.Cache.Internal
 {
     internal class KeyValueCollection<TObject, TKey> : IKeyValueCollection<TObject, TKey>
     {
-        private readonly Lazy<List<KeyValuePair<TKey, TObject>>> _items;
+        private readonly IReadOnlyCollection<KeyValuePair<TKey, TObject>> _items;
 
-        public KeyValueCollection(IEnumerable<KeyValuePair<TKey, TObject>> items,
+        public KeyValueCollection(IReadOnlyCollection<KeyValuePair<TKey, TObject>> items,
                                   IComparer<KeyValuePair<TKey, TObject>> comparer,
                                   SortReason sortReason,
                                   SortOptimisations optimisations)
         {
-            if (items == null) throw new ArgumentNullException(nameof(items));
- 
-             _items = new Lazy<List<KeyValuePair<TKey, TObject>>>(() => items.ToList());
+            _items = items ?? throw new ArgumentNullException(nameof(items));
             Comparer = comparer;
             SortReason = sortReason;
             Optimisations = optimisations;
@@ -26,7 +23,7 @@ namespace DynamicData.Cache.Internal
         public KeyValueCollection()
         {
             Optimisations = SortOptimisations.None;
-            _items = new Lazy<List<KeyValuePair<TKey, TObject>>>(() => new List<KeyValuePair<TKey, TObject>>());
+            _items = new List<KeyValuePair<TKey, TObject>>();
             Comparer = new KeyValueComparer<TObject, TKey>();
         }
 
@@ -38,9 +35,9 @@ namespace DynamicData.Cache.Internal
         /// </value>
         public IComparer<KeyValuePair<TKey, TObject>> Comparer { get; }
 
-        public int Count => _items.Value.Count;
+        public int Count => _items.Count;
 
-        public KeyValuePair<TKey, TObject> this[int index] => _items.Value[index];
+        public KeyValuePair<TKey, TObject> this[int index] => _items.ElementAt(index);
 
         public SortReason SortReason { get; }
 
@@ -48,7 +45,7 @@ namespace DynamicData.Cache.Internal
 
         public IEnumerator<KeyValuePair<TKey, TObject>> GetEnumerator()
         {
-            return _items.Value.GetEnumerator();
+            return _items.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/DynamicData/Cache/Internal/KeyValueCollection.cs
+++ b/DynamicData/Cache/Internal/KeyValueCollection.cs
@@ -8,14 +8,16 @@ namespace DynamicData.Cache.Internal
 {
     internal class KeyValueCollection<TObject, TKey> : IKeyValueCollection<TObject, TKey>
     {
-        private readonly List<KeyValuePair<TKey, TObject>> _items;
+        private readonly Lazy<List<KeyValuePair<TKey, TObject>>> _items;
 
         public KeyValueCollection(IEnumerable<KeyValuePair<TKey, TObject>> items,
                                   IComparer<KeyValuePair<TKey, TObject>> comparer,
                                   SortReason sortReason,
                                   SortOptimisations optimisations)
         {
-            _items = items?.ToList() ?? throw new ArgumentNullException(nameof(items));
+            if (items == null) throw new ArgumentNullException(nameof(items));
+ 
+             _items = new Lazy<List<KeyValuePair<TKey, TObject>>>(() => items.ToList());
             Comparer = comparer;
             SortReason = sortReason;
             Optimisations = optimisations;
@@ -24,7 +26,7 @@ namespace DynamicData.Cache.Internal
         public KeyValueCollection()
         {
             Optimisations = SortOptimisations.None;
-            _items = new List<KeyValuePair<TKey, TObject>>();
+            _items = new Lazy<List<KeyValuePair<TKey, TObject>>>(() => new List<KeyValuePair<TKey, TObject>>());
             Comparer = new KeyValueComparer<TObject, TKey>();
         }
 
@@ -36,9 +38,9 @@ namespace DynamicData.Cache.Internal
         /// </value>
         public IComparer<KeyValuePair<TKey, TObject>> Comparer { get; }
 
-        public int Count => _items.Count;
+        public int Count => _items.Value.Count;
 
-        public KeyValuePair<TKey, TObject> this[int index] => _items[index];
+        public KeyValuePair<TKey, TObject> this[int index] => _items.Value[index];
 
         public SortReason SortReason { get; }
 
@@ -46,7 +48,7 @@ namespace DynamicData.Cache.Internal
 
         public IEnumerator<KeyValuePair<TKey, TObject>> GetEnumerator()
         {
-            return _items.GetEnumerator();
+            return _items.Value.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/DynamicData/Cache/Internal/Page.cs
+++ b/DynamicData/Cache/Internal/Page.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
 using DynamicData.Annotations;
@@ -78,7 +79,7 @@ namespace DynamicData.Cache.Internal
 
                 var paged = _all.Skip(skip)
                     .Take(_request.Size)
-                    .ToList();
+                    .ToImmutableList();
 
                 _current = new KeyValueCollection<TObject, TKey>(paged, _all.Comparer, updates?.SortedItems.SortReason ?? SortReason.DataChanged, _all.Optimisations);
 

--- a/DynamicData/Cache/Internal/Virtualiser.cs
+++ b/DynamicData/Cache/Internal/Virtualiser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
 
@@ -71,7 +72,7 @@ namespace DynamicData.Cache.Internal
                 var previous = _current;
                 var virualised = _all.Skip(_parameters.StartIndex)
                                      .Take(_parameters.Size)
-                                     .ToList();
+                                     .ToImmutableList();
 
                 _current = new KeyValueCollection<TObject, TKey>(virualised, _all.Comparer, updates?.SortedItems.SortReason ?? SortReason.DataChanged, _all.Optimisations);
 

--- a/DynamicData/DynamicData.csproj
+++ b/DynamicData/DynamicData.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reactive" Version="[3.1.1,4)" />
   </ItemGroup>
 


### PR DESCRIPTION
While playing around with profiler I noticed a lot of CPU spikes and memory allocations were caused by toList calls in KeyValueCollection constructor. After I made the list Lazy I was able to reduce my test case run time almost 3 times ( I'll also try to submit PR for my benchmarks, soon)