### PR TITLE
- Updated to Reactive Extensions 4.0.0

### DIFF
--- a/DynamicData.Profile/DynamicData.Profile.csproj
+++ b/DynamicData.Profile/DynamicData.Profile.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   
@@ -14,7 +14,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,7 +24,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
+++ b/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="8.3.1" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="reactiveui" Version="8.4.1" />
+    <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 
 
@@ -22,7 +22,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
   </ItemGroup>
 
 

--- a/DynamicData.ReactiveUI/DynamicData.ReactiveUI.csproj
+++ b/DynamicData.ReactiveUI/DynamicData.ReactiveUI.csproj
@@ -7,7 +7,7 @@
     <ProjectReference Include="..\DynamicData\DynamicData.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="reactiveui" Version="8.3.1" />
+    <PackageReference Include="reactiveui" Version="8.4.1" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/DynamicData.Tests/DynamicData.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   
@@ -8,7 +8,7 @@
     <Copyright>Copyright Roland Pheasant 2011-2018</Copyright>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net452' or '$(TargetFramework)' == 'netcoreapp2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net46' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <DefineConstants>P_LINQ</DefineConstants>
   </PropertyGroup>
 
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -32,6 +32,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="[3.1.1,4)" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/DynamicData/DynamicData.csproj
+++ b/DynamicData/DynamicData.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.1;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="System.Reactive" Version="3.1.1" />
+    <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>P_LINQ</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
- Since Rx 4.0.0 only has .NET Standard 2.0 support removed .NEt Standard 1
- Since Rx 4.0.0 only has .NEt Framework 4.6 support removed 4.5
- Updated references ReactiveUI 8.4.1
- Updated test projects to .NET Core 2.1