### PR TITLE
Bugfix: When a changeset doesn't have indexes for removes, then the remove is not propogated

### DIFF
--- a/DynamicData.Tests/List/TransformFixture.cs
+++ b/DynamicData.Tests/List/TransformFixture.cs
@@ -58,6 +58,23 @@ namespace DynamicData.Tests.List
         }
 
         [Fact]
+        public void RemoveWithoutIndex()
+        {
+            const string key = "Adult1";
+            var person = new Person(key, 50);
+
+            var results = _source.Connect().RemoveIndex().Transform(_transformFactory).AsAggregator();
+
+            _source.Add(person);
+            _source.Remove(person);
+
+            results.Messages.Count.Should().Be(2, "Should be 2 updates");
+            results.Messages[0].Adds.Should().Be(1, "Should be 1 addes");
+            results.Messages[1].Removes.Should().Be(1, "Should be 1 removes");
+            results.Data.Count.Should().Be(0, "Should be nothing cached");
+        }
+
+        [Fact]
         public void Update()
         {
             const string key = "Adult1";

--- a/DynamicData/List/Internal/Transformer.cs
+++ b/DynamicData/List/Internal/Transformer.cs
@@ -153,11 +153,11 @@ namespace DynamicData.List.Internal
 
                             if (hasIndex)
                             {
-                                transformed.RemoveAt(item.Item.CurrentIndex);
+                                transformed.RemoveAt(change.CurrentIndex);
                             }
                             else
                             {
-                                var toremove = transformed.FirstOrDefault(t => ReferenceEquals(t.Source, t));
+                                var toremove = transformed.FirstOrDefault(t => ReferenceEquals(t.Source, change.Current));
 
                                 if (toremove != null)
                                     transformed.Remove(toremove);
@@ -173,7 +173,7 @@ namespace DynamicData.List.Internal
                             }
                             else
                             {
-                                var toremove = transformed.Where(t => ReferenceEquals(t.Source, t));
+                                var toremove = transformed.Where(t => item.Range.Any(current => ReferenceEquals(t.Source, current)));
                                 transformed.RemoveMany(toremove);
                             }
 


### PR DESCRIPTION
I found this bug after creating a combined list and noticed that in the changesets all indexes were set to -1.