### PR TITLE
Add SourceLink

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>7.2</LangVersion>
+    <DefaultItemExcludes>$(DefaultItemExcludes);*.DotSettings;*.ncrunchproject</DefaultItemExcludes>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors>Roland Pheasant</Authors>
+    <Owners>Roland Pheasant</Owners>
+    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/RolandPheasant/DynamicData</PackageProjectUrl>
+    <Copyright>Copyright Roland Pheasant 2011-2018</Copyright>
+    <PackageTags>DynamicData;Dynamic;Data;Rx;Reactive;Observable;Cache;Binding;ObservableCache;ObservableList;ObservableCollection;Collection;Linq</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(APPVEYOR)' == 'True'">
+    <Deterministic>true</Deterministic>
+    <DeterministicSourcePaths>true</DeterministicSourcePaths>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(NCrunch)' == '1'">
+    <EnableSourceLink>false</EnableSourceLink>
+    <EnableSourceControlManagerQueries>false</EnableSourceControlManagerQueries>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/DynamicData.Profile/DynamicData.Profile.csproj
+++ b/DynamicData.Profile/DynamicData.Profile.csproj
@@ -5,10 +5,6 @@
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   
-  <PropertyGroup>
-    <Copyright>Copyright Roland Pheasant 2011-2018</Copyright>
-  </PropertyGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\DynamicData\DynamicData.csproj" />
   </ItemGroup>

--- a/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
+++ b/DynamicData.ReactiveUI.Tests/DynamicData.ReactiveUI.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,7 +13,6 @@
     <PackageReference Include="System.Reactive" Version="4.0.0" />
   </ItemGroup>
 
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
@@ -24,10 +22,5 @@
     <PackageReference Include="FluentAssertions" Version="4.19.3" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="4.0.0" />
   </ItemGroup>
-
-
-  <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
-  </PropertyGroup>
 
 </Project>

--- a/DynamicData.ReactiveUI/DynamicData.ReactiveUI.csproj
+++ b/DynamicData.ReactiveUI/DynamicData.ReactiveUI.csproj
@@ -2,24 +2,19 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\DynamicData\DynamicData.csproj" />
   </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="reactiveui" Version="8.4.1" />
   </ItemGroup>
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <Authors>Roland Pheasant</Authors>
-    <Owners>Roland Pheasant</Owners>
     <Title>Dynamic Data / Reactive UI intergration</Title>
-    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/RolandPheasant/DynamicData</PackageProjectUrl>
     <Description>
 Make reactive ui even more powerful by integrating with dynamic data and making use of it's numerious operators.
 Dynamic data provides an observable cache and an observable list with at least 50 collection specific operators for each.
@@ -27,12 +22,6 @@ Dynamic data provides an observable cache and an observable list with at least 5
     <Summary>
       Integrate dynamic data observable collections with ReactiveUI
     </Summary>
-    <Copyright>Copyright Roland Pheasant 2011-2018</Copyright>
-    <Tags>DynamicData ReactiveUI Dynamic Data Rx Reactive Observable Cache Binding ObservableCache ObservableList ObservableCollection Collection Linq</Tags>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <RepositoryUrl>https://github.com/RolandPheasant/DynamicData</RepositoryUrl>
-    <PackageTags>DynamicData Dynamic Data Rx Reactive Observable Cache Binding ObservableCache ObservableList ObservableCollection Collection Linq</PackageTags>
   </PropertyGroup>
-
 
 </Project>

--- a/DynamicData.Tests/DynamicData.Tests.csproj
+++ b/DynamicData.Tests/DynamicData.Tests.csproj
@@ -3,18 +3,9 @@
     <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
-  
-  <PropertyGroup>
-    <Copyright>Copyright Roland Pheasant 2011-2018</Copyright>
-  </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net46' or '$(TargetFramework)' == 'netcoreapp2.1'">
     <DefineConstants>P_LINQ</DefineConstants>
-  </PropertyGroup>
-
-
-  <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DynamicData.sln
+++ b/DynamicData.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".other", ".other", "{DFCC45F8-251C-4D78-AF9B-15C1EDF0E603}"
 	ProjectSection(SolutionItems) = preProject
 		appveyor.yml = appveyor.yml
+		Directory.Build.props = Directory.Build.props
 		NuGet.Config = NuGet.Config
 		README.md = README.md
 		ReleaseNotes.md = ReleaseNotes.md
@@ -112,5 +113,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2495D109-BD85-4568-9B27-06D36E6EF562}
 	EndGlobalSection
 EndGlobal

--- a/DynamicData/DynamicData.csproj
+++ b/DynamicData/DynamicData.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,26 +14,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Authors>Roland Pheasant</Authors>
-    <Owners>Roland Pheasant</Owners>
     <Title>Dynamic Data</Title>
-    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/RolandPheasant/DynamicData</PackageProjectUrl>
     <Description>
 Bring the power of Rx to collections using Dynamic Data.
 Dynamic Data is a comprehensive caching and data manipulation solution which introduces domain centric observable collections.
       Linq extensions enable dynamic filtering, sorting, grouping, transforms, binding, pagination, data virtualisation, expiration, disposal management plus more.
 </Description>
-    <Copyright>Copyright Roland Pheasant 2011-2018</Copyright>
-    <Tags>DynamicData Dynamic Data Rx Reactive Observable Cache Binding ObservableCache ObservableList ObservableCollection Collection Linq</Tags>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <RepositoryUrl>https://github.com/RolandPheasant/DynamicData</RepositoryUrl>
-    <PackageTags>DynamicData Dynamic Data Rx Reactive Observable Cache Binding ObservableCache ObservableList ObservableCollection Collection Linq</PackageTags>
   </PropertyGroup>
-
-  <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
-  </PropertyGroup>
-
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,30 +18,19 @@
   nuget:
     disable_publish_on_pr: true
   build_script:
-  - cmd: >-
+  - cmd: |
       dotnet --info
-
       dotnet build DynamicData.sln --configuration Release /p:Version=%APPVEYOR_BUILD_VERSION%
-      
-      dotnet pack DynamicData\DynamicData.csproj --configuration Release --no-build --include-symbols --include-source /p:Version=%APPVEYOR_BUILD_VERSION%
- 
-      dotnet pack DynamicData.ReactiveUI\DynamicData.ReactiveUI.csproj --configuration Release --no-build --include-symbols --include-source /p:Version=%APPVEYOR_BUILD_VERSION%
-
+      dotnet pack DynamicData\DynamicData.csproj --configuration Release --no-build /p:Version=%APPVEYOR_BUILD_VERSION%
+      dotnet pack DynamicData.ReactiveUI\DynamicData.ReactiveUI.csproj --configuration Release --no-build /p:Version=%APPVEYOR_BUILD_VERSION%
       appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\DynamicData\bin\Release\DynamicData.%APPVEYOR_BUILD_VERSION%.nupkg
-      
-      appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\DynamicData\bin\Release\DynamicData.%APPVEYOR_BUILD_VERSION%.symbols.nupkg
-
       appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\DynamicData.ReactiveUI\bin\Release\DynamicData.ReactiveUI.%APPVEYOR_BUILD_VERSION%.nupkg
-
-      appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\DynamicData.ReactiveUI\bin\Release\DynamicData.ReactiveUI.%APPVEYOR_BUILD_VERSION%.symbols.nupkg
 
   test: off
   test_script:
-  - cmd: >-
+  - cmd: |
       cd %APPVEYOR_BUILD_FOLDER%
-
       dotnet test DynamicData.Tests\DynamicData.Tests.csproj --configuration Release --no-build
-
       dotnet test DynamicData.ReactiveUI.Tests\DynamicData.ReactiveUI.Tests.csproj --configuration Release --no-build
 
   deploy:
@@ -73,9 +62,8 @@
     account_feed: true
     disable_publish_on_pr: true
   before_build:
-  - cmd: >-
+  - cmd: |
       appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-
       nuget restore DynamicData.sln
   build:
     project: DynamicData.sln
@@ -84,9 +72,8 @@
     include_nuget_references: true
     verbosity: minimal
   after_build:
-  - cmd: >-
+  - cmd: |
       7z a DynamicData.zip %APPVEYOR_BUILD_FOLDER%\DynamicData\bin\Release\*.*
-
       appveyor PushArtifact DynamicData.zip
   test: off
  # test_script:
@@ -126,30 +113,18 @@
     disable_publish_on_pr: true
   
   build_script:
-  - cmd: >-
+  - cmd: |
       dotnet --info
-
       dotnet build DynamicData.sln --configuration Release /p:Version=%APPVEYOR_BUILD_VERSION%
-      
-      dotnet pack DynamicData\DynamicData.csproj --configuration Release --no-build --include-symbols --include-source /p:Version=%APPVEYOR_BUILD_VERSION%
-      
-      dotnet pack DynamicData.ReactiveUI\DynamicData.ReactiveUI.csproj --configuration Release --no-build --include-symbols --include-source /p:Version=%APPVEYOR_BUILD_VERSION%
-
+      dotnet pack DynamicData\DynamicData.csproj --configuration Release --no-build /p:Version=%APPVEYOR_BUILD_VERSION%
+      dotnet pack DynamicData.ReactiveUI\DynamicData.ReactiveUI.csproj --configuration Release --no-build /p:Version=%APPVEYOR_BUILD_VERSION%
       appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\DynamicData\bin\Release\DynamicData.%APPVEYOR_BUILD_VERSION%.nupkg
-      
-      appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\DynamicData\bin\Release\DynamicData.%APPVEYOR_BUILD_VERSION%.symbols.nupkg
-
       appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\DynamicData.ReactiveUI\bin\Release\DynamicData.ReactiveUI.%APPVEYOR_BUILD_VERSION%.nupkg
-
-      appveyor PushArtifact %APPVEYOR_BUILD_FOLDER%\DynamicData.ReactiveUI\bin\Release\DynamicData.ReactiveUI.%APPVEYOR_BUILD_VERSION%.symbols.nupkg
-
 
   test: off
   # Hangs indefinitely and I do not know why as the same command works locally
   test_script:
-  - cmd: >-
+  - cmd: |
       cd %APPVEYOR_BUILD_FOLDER%
-
       dotnet test DynamicData.Tests\DynamicData.Tests.csproj --configuration Release --no-build
-
       dotnet test DynamicData.ReactiveUI.Tests\DynamicData.ReactiveUI.Tests.csproj --configuration Release --no-build


### PR DESCRIPTION
Adds SourceLink support. Fixes #147.

Here's what I did:

- Added a `Directory.Build.props` file for the common properties across all projects. This is [automatically picked up by MSBuild](https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2017).
- Cleaned up the csproj files to remove the properties I moved to `Directory.Build.props`
- Made the build deterministic on AppVeyor, because why not ¯\\\_(ツ)\_/¯
- Disabled SourceLink if you happen to use NCrunch (it just gets in the way)
- Added the pdb files to the NuGet and removed the symbol packages as they are now redundant.
- Set `IsPackable` to false as a default, and set it to true in the two projects that require it. This one is not really needed, but it may be *cleaner* this way.

