### PR TITLE
Use portable PDBs to make SourceLink work on the .NET Framework

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>7.2</LangVersion>
     <DefaultItemExcludes>$(DefaultItemExcludes);*.DotSettings;*.ncrunchproject</DefaultItemExcludes>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/RolandPheasant/DynamicData/pull/148#issuecomment-418180968

