### PR TITLE
Allow TransformMany with a Func<TSource, IObservableList<TDestination>>

### DIFF
--- a/DynamicData.Tests/List/TransformManyObservableListFixture.cs
+++ b/DynamicData.Tests/List/TransformManyObservableListFixture.cs
@@ -1,0 +1,188 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using DynamicData.Tests.Domain;
+using FluentAssertions;
+using Xunit;
+
+namespace DynamicData.Tests.List
+{
+    public class TransformManyObservableListFixture
+    {
+        [Fact]
+        public void FlattenObservableList()
+        {
+            var children = Enumerable.Range(1, 100).Select(i => new Person("Name" + i, i)).ToArray();
+
+            int childIndex = 0;
+            var parents = Enumerable.Range(1, 50)
+                .Select(i =>
+                {
+                    var parent = new Parent(i, new[]
+                    {
+                        children[childIndex],
+                        children[childIndex + 1]
+                    });
+
+                    childIndex = childIndex + 2;
+                    return parent;
+                }).ToArray();
+
+
+            using (var source = new SourceList<Parent>())
+            using (var aggregator = source.Connect()
+                .TransformMany(p => p.Children)
+                .AsAggregator())
+            {
+                source.AddRange(parents);
+
+                aggregator.Data.Count.Should().Be(100);
+
+                //add a child to an observable collection and check the new item is added
+                parents[0].Children.Add(new Person("NewlyAddded", 100));
+                aggregator.Data.Count.Should().Be(101);
+
+                ////remove first parent and check children have gone
+                source.RemoveAt(0);
+                aggregator.Data.Count.Should().Be(98);
+
+                //check items can be cleared and then added back in
+                var childrenInZero = parents[1].Children.Items.ToArray();
+                parents[1].Children.Clear();
+                aggregator.Data.Count.Should().Be(96);
+                parents[1].Children.AddRange(childrenInZero);
+                aggregator.Data.Count.Should().Be(98);
+
+                //replace produces an update
+                var replacedChild = parents[1].Children.Items.First();
+                var replacement = new Person("Replacement", 100);
+                parents[1].Children.Replace(replacedChild, replacement);
+                aggregator.Data.Count.Should().Be(98);
+
+                aggregator.Data.Items.Contains(replacement).Should().BeTrue();
+                aggregator.Data.Items.Contains(replacedChild).Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public void FlattenReadOnlyObservableList()
+        {
+            var children = Enumerable.Range(1, 100).Select(i => new Person("Name" + i, i)).ToArray();
+
+            int childIndex = 0;
+            var parents = Enumerable.Range(1, 50)
+                .Select(i =>
+                {
+                    var parent = new Parent(i, new[]
+                    {
+                        children[childIndex],
+                        children[childIndex + 1]
+                    });
+
+                    childIndex = childIndex + 2;
+                    return parent;
+                }).ToArray();
+
+
+            using (var source = new SourceList<Parent>())
+            using (var aggregator = source.Connect()
+                .TransformMany(p => p.ChildrenReadonly)
+                .AsAggregator())
+            {
+                source.AddRange(parents);
+
+                aggregator.Data.Count.Should().Be(100);
+
+                //add a child to an observable collection and check the new item is added
+                parents[0].Children.Add(new Person("NewlyAddded", 100));
+                aggregator.Data.Count.Should().Be(101);
+
+                ////remove first parent and check children have gone
+                source.RemoveAt(0);
+                aggregator.Data.Count.Should().Be(98);
+
+
+                //check items can be cleared and then added back in
+                var childrenInZero = parents[1].Children.Items.ToArray();
+                parents[1].Children.Clear();
+                aggregator.Data.Count.Should().Be(96);
+                parents[1].Children.AddRange(childrenInZero);
+                aggregator.Data.Count.Should().Be(98);
+
+                //replace produces an update
+                var replacedChild = parents[1].Children.Items.First();
+                var replacement = new Person("Replacement", 100);
+                parents[1].Children.Replace(replacedChild, replacement);
+                aggregator.Data.Count.Should().Be(98);
+
+                //replace produces an update
+                aggregator.Data.Items.Contains(replacement).Should().BeTrue();
+                aggregator.Data.Items.Contains(replacedChild).Should().BeFalse();
+            }
+        }
+
+        [Fact]
+        public void ObservableListWithoutInitialData()
+        {
+            using (var parents = new SourceList<Parent>())
+            {
+
+                var collection = parents.Connect()
+                    .TransformMany(d => d.Children)
+                    .AsObservableList();
+
+                var parent = new Parent();
+                parents.Add(parent);
+
+                collection.Count.Should().Be(0);
+
+                parent.Children.Add(new Person("child1", 1));
+                collection.Count.Should().Be(1);
+
+                parent.Children.Add(new Person("child2", 2));
+                collection.Count.Should().Be(2);
+            }
+        }
+
+        [Fact]
+        public void ReadOnlyObservableListWithoutInitialData()
+        {
+            using (var parents = new SourceList<Parent>())
+            {
+                var collection = parents.Connect()
+                    .TransformMany(d => d.ChildrenReadonly)
+                    .AsObservableList();
+
+                var parent = new Parent();
+                parents.Add(parent);
+
+                collection.Count.Should().Be(0);
+
+                parent.Children.Add(new Person("child1", 1));
+                collection.Count.Should().Be(1);
+
+                parent.Children.Add(new Person("child2", 2));
+                collection.Count.Should().Be(2);
+            }
+        }
+
+        private class Parent
+        {
+            public SourceList<Person> Children;
+            public IObservableList<Person> ChildrenReadonly { get; }
+
+            public int Id { get; }
+
+            public Parent(int id, params Person[] children) : this()
+            {
+                Id = id;
+                Children.AddRange(children);                
+            }
+
+            public Parent()
+            {
+                Children = new SourceList<Person>();
+                ChildrenReadonly = Children.AsObservableList();
+            }
+        }
+    }
+}

--- a/DynamicData/List/ObservableListEx.cs
+++ b/DynamicData/List/ObservableListEx.cs
@@ -791,7 +791,21 @@ namespace DynamicData
         {
             return new TransformMany<TSource, TDestination>(source, manyselector, equalityComparer).Run();
         }
-        
+
+        /// <summary>
+        /// Flatten the nested observable collection, and  observe subsequentl observable collection changes
+        /// </summary>
+        /// <typeparam name="TDestination">The type of the destination.</typeparam>
+        /// <typeparam name="TSource">The type of the source.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="manyselector">The manyselector.</param>
+        /// <param name="equalityComparer">Used when an item has been replaced to determine whether child items are the same as previous children</param>
+        public static IObservable<IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source,
+            Func<TSource, IObservableList<TDestination>> manyselector,
+            IEqualityComparer<TDestination> equalityComparer = null)
+        {
+            return new TransformMany<TSource, TDestination>(source, manyselector, equalityComparer).Run();
+        }
 
         /// <summary>
         /// Selects distinct values from the source, using the specified value selector


### PR DESCRIPTION
Hi!

This PR solves #158 
- Added new constructor for TransformMany and corresponding overload in ObservableListEx
- Duplicated and adjusted the existing unit tests "TransformManyObservableCollectionFixtures" to test the new overload

Note: I'm not sure the "CreateCollectionFromList" method is the nicest way, especially since it cannot store the subscription to the child changes anywhere. I'm thinking if a larger change is needed: If there would be a more flexible ManyContainer, perhaps subclassed separately for the existing and the new use case, the subscription could be managed there. For that I would like some feedback from you before digging deeper.

Thanks!