### PR TITLE
Fix list's filter

### DIFF
--- a/DynamicData.Tests/List/FilterWithObservable.cs
+++ b/DynamicData.Tests/List/FilterWithObservable.cs
@@ -79,6 +79,36 @@ namespace DynamicData.Tests.List
         }
 
         [Fact]
+        public void RemoveFiltered()
+        {
+            var person = new Person("P1", 1);
+
+            _source.Add(person);
+            _results.Data.Count.Should().Be(0, "Should be 0 people in the cache");
+            _filter.OnNext(p => p.Age >= 1);
+            _results.Data.Count.Should().Be(1, "Should be 1 people in the cache");
+
+            _source.Remove(person);
+
+            _results.Data.Count.Should().Be(0, "Should be 0 people in the cache");
+        }
+
+        [Fact]
+        public void RemoveFilteredRange()
+        {
+            var people = Enumerable.Range(1, 10).Select(i => new Person("P" + i, i)).ToArray();
+
+            _source.AddRange(people);
+            _results.Data.Count.Should().Be(0, "Should be 0 people in the cache");
+            _filter.OnNext(p => p.Age > 5);
+            _results.Data.Count.Should().Be(5, "Should be 5 people in the cache");
+
+            _source.RemoveRange(5, 5);
+
+            _results.Data.Count.Should().Be(0, "Should be 0 people in the cache");
+        }
+
+        [Fact]
         public void ChainFilters()
         {
             var filter2 = new BehaviorSubject<Func<Person, bool>>(person1 => person1.Age > 20);

--- a/DynamicData/List/Internal/Filter.cs
+++ b/DynamicData/List/Internal/Filter.cs
@@ -168,14 +168,12 @@ namespace DynamicData.List.Internal
                     }
                     case ListChangeReason.Remove:
                     {
-                        var change = item.Item;
-                        if (change.Current.IsMatch)
-                            filtered.Remove(change.Current);
+                        filtered.Remove(item.Item.Current);
                         break;
                     }
                     case ListChangeReason.RemoveRange:
                     {
-                        filtered.RemoveMany(item.Range.Where(t => t.IsMatch));
+                        filtered.RemoveMany(item.Range);
                         break;
                     }
                     case ListChangeReason.Clear:


### PR DESCRIPTION
There is an error with dynamic filter applied to SourceList - #164 

The error exists because `IsMatch` might be not actual in `filteredResult`.
Transform is not called on remove, and is not called when filter is changed, so internally it saves previous state of the matched item, which is returned on remove.
And if it was updated on remove, `IsMatch` might be set to `false` because item was internally changed and must be filtered off, but item will not be removed.

The fast fix is to remove the optimization check on `IsMatch` when remove is called.
