### PR TITLE
ArgumentOutOfRangeException thrown at TransformMany.

### DIFF
--- a/DynamicData/List/Internal/TransformMany.cs
+++ b/DynamicData/List/Internal/TransformMany.cs
@@ -196,6 +196,11 @@ namespace DynamicData.List.Internal
                             yield return new Change<TDestination>(change.Reason, items);
                         }
                             break;
+
+                        case ListChangeReason.Refresh:
+                            // handle case without throwing an exception.
+                            break;
+
                         default:
                             throw new ArgumentOutOfRangeException();
                     }


### PR DESCRIPTION
Fixes ArgumentOutOfRangeException being thrown at TransformMany when change comes from a refresh.