### PR TITLE
Fix TransformMany

### DIFF
--- a/DynamicData.Tests/Cache/TransformManyRefreshFixture.cs
+++ b/DynamicData.Tests/Cache/TransformManyRefreshFixture.cs
@@ -1,0 +1,79 @@
+﻿using DynamicData.Tests.Domain;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DynamicData.Tests.Cache
+{
+
+    public class TransformManyRefreshFixture: IDisposable
+    {
+        private readonly ISourceCache<PersonWithFriends, string> _source;
+        private readonly ChangeSetAggregator<PersonWithFriends, string> _results;
+
+        public TransformManyRefreshFixture()
+        {
+            _source = new SourceCache<PersonWithFriends, string>(p => p.Key);
+
+            _results = _source.Connect()
+                .AutoRefresh()
+                .TransformMany(p => p.Friends, p => p.Name)
+                .AsAggregator();
+        }
+
+        public void Dispose()
+        {
+            _source.Dispose();
+            _results.Dispose();
+        }
+
+        [Fact]
+        public void AutoRefresh()
+        {
+            var person = new PersonWithFriends("Person", 50);
+            _source.AddOrUpdate(person);
+
+            person.Friends = new[]
+            {
+                new PersonWithFriends("Friend1", 40),
+                new PersonWithFriends("Friend2", 45)
+            };
+
+            _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
+            _results.Data.Lookup("Friend1").HasValue.Should().BeTrue();
+            _results.Data.Lookup("Friend2").HasValue.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AutoRefreshOnOtherProperty()
+        {
+            var friends = new List<PersonWithFriends> { new PersonWithFriends("Friend1", 40) };
+            var person = new PersonWithFriends("Person", 50, friends);
+            _source.AddOrUpdate(person);
+
+            friends.Add(new PersonWithFriends("Friend2", 45));
+            person.Age = 55;
+
+            _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
+            _results.Data.Lookup("Friend1").HasValue.Should().BeTrue();
+            _results.Data.Lookup("Friend2").HasValue.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DirectRefresh()
+        {
+            var friends = new List<PersonWithFriends> {new PersonWithFriends("Friend1", 40)};
+            var person = new PersonWithFriends("Person", 50, friends);
+            _source.AddOrUpdate(person);
+
+            friends.Add(new PersonWithFriends("Friend2", 45));
+            _source.Refresh(person);
+            
+            _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
+            _results.Data.Lookup("Friend1").HasValue.Should().BeTrue();
+            _results.Data.Lookup("Friend2").HasValue.Should().BeTrue();
+        }
+
+    }
+}

--- a/DynamicData.Tests/Cache/TransformManySimpleFixture.cs
+++ b/DynamicData.Tests/Cache/TransformManySimpleFixture.cs
@@ -1,7 +1,6 @@
 ﻿using DynamicData.Tests.Domain;
 using FluentAssertions;
 using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace DynamicData.Tests.Cache
@@ -111,21 +110,6 @@ namespace DynamicData.Tests.Cache
             _results.Data.Lookup("Child1").HasValue.Should().BeTrue();
             _results.Data.Lookup("Child3").HasValue.Should().BeTrue();
             _results.Data.Lookup("Child5").HasValue.Should().BeTrue();
-        }
-
-        [Fact]
-        public void Refresh()
-        {
-            var relations = new List<Person> { new Person("Child1", 1) };
-            var parent = new PersonWithChildren("parent", 50, relations);
-            _source.AddOrUpdate(parent);
-
-            relations.Add(new Person("Child2", 2));
-            _source.Refresh(parent);
-
-            _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
-            _results.Data.Lookup("Child1").HasValue.Should().BeTrue();
-            _results.Data.Lookup("Child2").HasValue.Should().BeTrue();
         }
 
     }

--- a/DynamicData.Tests/Cache/TransformManySimpleFixture.cs
+++ b/DynamicData.Tests/Cache/TransformManySimpleFixture.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using DynamicData.Tests.Domain;
+﻿using DynamicData.Tests.Domain;
 using FluentAssertions;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace DynamicData.Tests.Cache
@@ -111,5 +112,21 @@ namespace DynamicData.Tests.Cache
             _results.Data.Lookup("Child3").HasValue.Should().BeTrue();
             _results.Data.Lookup("Child5").HasValue.Should().BeTrue();
         }
+
+        [Fact]
+        public void Refresh()
+        {
+            var relations = new List<Person> { new Person("Child1", 1) };
+            var parent = new PersonWithChildren("parent", 50, relations);
+            _source.AddOrUpdate(parent);
+
+            relations.Add(new Person("Child2", 2));
+            _source.Refresh(parent);
+
+            _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
+            _results.Data.Lookup("Child1").HasValue.Should().BeTrue();
+            _results.Data.Lookup("Child2").HasValue.Should().BeTrue();
+        }
+
     }
 }

--- a/DynamicData.Tests/Domain/PersonWithFriends.cs
+++ b/DynamicData.Tests/Domain/PersonWithFriends.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Linq;
+using DynamicData.Binding;
+
+namespace DynamicData.Tests.Domain
+{
+    public class PersonWithFriends : AbstractNotifyPropertyChanged, IKey<string>
+    {
+        private int _age;
+        private IEnumerable<PersonWithFriends> _friends;
+
+        public PersonWithFriends(string name, int age)
+            : this(name, age, Enumerable.Empty<PersonWithFriends>())
+        {
+        }
+
+        public PersonWithFriends(string name, int age, IEnumerable<PersonWithFriends> friends)
+        {
+            Name = name;
+            _age = age;
+            _friends = friends;
+            Key = name;
+        }
+
+        public string Name { get; }
+
+        public int Age
+        {
+            get => _age;
+            set => SetAndRaise(ref _age, value);
+        }
+
+        public IEnumerable<PersonWithFriends> Friends
+        {
+            get => _friends;
+            set => SetAndRaise(ref _friends, value);
+        }
+
+        public override string ToString()
+        {
+            return $"{Name}. {Age}";
+        }
+
+        #region Implementation of IKey<out string>
+
+        /// <summary>
+        ///     The key
+        /// </summary>
+        public string Key { get; }
+
+        #endregion
+    }
+}

--- a/DynamicData.Tests/List/TransformManyRefreshFixture.cs
+++ b/DynamicData.Tests/List/TransformManyRefreshFixture.cs
@@ -1,0 +1,80 @@
+using DynamicData.Tests.Domain;
+using DynamicData.Tests.Utilities;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DynamicData.Tests.List
+{
+    public class TransformManyRefreshFixture : IDisposable
+    {
+        private readonly ISourceList<PersonWithFriends> _source;
+        private readonly ChangeSetAggregator<PersonWithFriends> _results;
+
+        public TransformManyRefreshFixture()
+        {
+            _source = new SourceList<PersonWithFriends>();
+
+            _results = _source.Connect()
+                .AutoRefresh()
+                .TransformMany(p => p.Friends.RecursiveSelect(r => r.Friends))
+                .AsAggregator();
+        }
+
+        public void Dispose()
+        {
+            _source.Dispose();
+            _results.Dispose();
+        }
+
+        [Fact]
+        public void AutoRefresh()
+        {
+            var friend1 = new PersonWithFriends("Friend1", 40);
+            var friend2 = new PersonWithFriends("Friend2", 45);
+
+            var person = new PersonWithFriends("Person", 50);
+            _source.Add(person);
+
+            person.Friends = new[] {friend1, friend2};
+
+            _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
+            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {friend1, friend2});
+        }
+
+        [Fact]
+        public void AutoRefreshOnOtherProperty()
+        {
+            var friend1 = new PersonWithFriends("Friend1", 40);
+            var friend2 = new PersonWithFriends("Friend2", 45);
+            var friends = new List<PersonWithFriends> {friend1};
+            var person = new PersonWithFriends("Person", 50, friends);
+            _source.Add(person);
+
+            friends.Add(friend2);
+            person.Age = 55;
+
+            _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
+            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {friend1, friend2});
+        }
+
+        [Fact]
+        public void AutoRefreshRecursive()
+        {
+            var friend1 = new PersonWithFriends("Friend1", 30);
+            var friend2 = new PersonWithFriends("Friend2", 35);
+            var friend3 = new PersonWithFriends("Friend3", 40, new[] {friend1});
+            var friend4 = new PersonWithFriends("Friend4", 45, new[] {friend2});
+
+            var person = new PersonWithFriends("Person", 50, new[] {friend3});
+            _source.Add(person);
+
+            person.Friends = new[] {friend4};
+
+            _results.Data.Count.Should().Be(2, "Should be 2 in the cache");
+            _results.Data.Items.ShouldAllBeEquivalentTo(new[] {friend4, friend2});
+        }
+
+    }
+}

--- a/DynamicData/Cache/ObservableCacheEx.cs
+++ b/DynamicData/Cache/ObservableCacheEx.cs
@@ -2225,6 +2225,80 @@ namespace DynamicData
         /// <typeparam name="TKey">The type of the key.</typeparam>
         /// <param name="source">The source.</param>
         /// <param name="transformFactory">The transform factory.</param>
+        /// <param name="transformOnRefresh">Should a new transform be applied when a refresh event is received</param>
+        /// <returns>
+        /// A transformed update collection
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">source
+        /// or
+        /// transformFactory</exception>
+        public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source,
+            Func<TSource, TDestination> transformFactory,
+            bool transformOnRefresh)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (transformFactory == null) throw new ArgumentNullException(nameof(transformFactory));
+
+            return source.Transform((current, previous, key) => transformFactory(current), transformOnRefresh);
+        }
+
+        /// <summary>
+        /// Projects each update item to a new form using the specified transform function
+        /// </summary>
+        /// <typeparam name="TDestination">The type of the destination.</typeparam>
+        /// <typeparam name="TSource">The type of the source.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="transformFactory">The transform factory.</param>
+        /// <param name="transformOnRefresh">Should a new transform be applied when a refresh event is received</param>
+        /// <returns>
+        /// A transformed update collection
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">source
+        /// or
+        /// transformFactory</exception>
+        public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source,
+            Func<TSource, TKey, TDestination> transformFactory,
+            bool transformOnRefresh)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (transformFactory == null) throw new ArgumentNullException(nameof(transformFactory));
+            return source.Transform((current, previous, key) => transformFactory(current, key), transformOnRefresh);
+        }
+
+        /// <summary>
+        /// Projects each update item to a new form using the specified transform function
+        /// </summary>
+        /// <typeparam name="TDestination">The type of the destination.</typeparam>
+        /// <typeparam name="TSource">The type of the source.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="transformFactory">The transform factory.</param>
+        /// <param name="transformOnRefresh">Should a new transform be applied when a refresh event is received</param>
+        /// <returns>
+        /// A transformed update collection
+        /// </returns>
+        /// <exception cref="System.ArgumentNullException">source
+        /// or
+        /// transformFactory</exception>
+        public static IObservable<IChangeSet<TDestination, TKey>> Transform<TDestination, TSource, TKey>(this IObservable<IChangeSet<TSource, TKey>> source,
+            Func<TSource, Optional<TSource>, TKey, TDestination> transformFactory,
+            bool transformOnRefresh)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (transformFactory == null) throw new ArgumentNullException(nameof(transformFactory));
+
+            return new Transform<TDestination, TSource, TKey>(source, transformFactory, transformOnRefresh: transformOnRefresh).Run();
+        }
+
+        /// <summary>
+        /// Projects each update item to a new form using the specified transform function
+        /// </summary>
+        /// <typeparam name="TDestination">The type of the destination.</typeparam>
+        /// <typeparam name="TSource">The type of the source.</typeparam>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="transformFactory">The transform factory.</param>
         /// <param name="forceTransform">Invoke to force a new transform for items matching the selected objects</param>
         /// <returns>
         /// A transformed update collection

--- a/DynamicData/List/ChangeAwareList.cs
+++ b/DynamicData/List/ChangeAwareList.cs
@@ -184,9 +184,10 @@ namespace DynamicData
             if (index < 0) throw new ArgumentException($"{nameof(index)} cannot be negative");
             if (index > _innerList.Count) throw new ArgumentException($"{nameof(index)} cannot be greater than the size of the collection");
 
+            var previous = _innerList[index];
             _innerList[index] = item;
 
-            _changes.Add(new Change<T>(ListChangeReason.Refresh, item, index));
+            _changes.Add(new Change<T>(ListChangeReason.Refresh, item, previous, index));
         }
 
         /// <summary>

--- a/DynamicData/List/Internal/TransformMany.cs
+++ b/DynamicData/List/Internal/TransformMany.cs
@@ -67,7 +67,7 @@ namespace DynamicData.List.Internal
             if (_childChanges != null)
                 return CreateWithChangeset();
 
-            return _source.Transform(item => new ManyContainer(_manyselector(item)))
+            return _source.Transform(item => new ManyContainer(_manyselector(item).ToArray()), true)
                 .Select(changes => new ChangeSet<TDestination>(new DestinationEnumerator(changes, _equalityComparer))).NotEmpty();
         }
           
@@ -158,6 +158,7 @@ namespace DynamicData.List.Internal
                         }
                             break;
                         case ListChangeReason.Replace:
+                        case ListChangeReason.Refresh:
                         {
                             //this is difficult as we need to discover adds and removes (and perhaps replaced)
                             var currentItems = change.Item.Current.Destination.AsArray();


### PR DESCRIPTION
Fixes #173
Added `Transform` interface with `transformOnRefresh` to cache extensions (similar to list)
Changed TransformMany in SourceCache:
- enable `transformOnRefresh` if without `childChanges`
- added `ToList()` to force calculate `Select`, else Previous items and Current items will be equal
- in case when there is `childChanges` there was strange applying of `lock` - `Select` was iterated outside locked area

Do I need to make `transformOnRefresh` optional for TransformMany and add it to interface?
Probably similar stuff must be done for SourceList.

I think, that I have messed up with `lock`