### PR TITLE
Set the ReactiveUI framework to register the interfaces as Obsolete

### DIFF
--- a/DynamicData.ReactiveUI.Tests/Fixtures/BindChangeSetFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/BindChangeSetFixture.cs
@@ -6,6 +6,7 @@ using ReactiveUI;
 using ReactiveUI.Legacy;
 using Xunit;
 
+#pragma warning disable CS0618 // Using legacy code.
 
 namespace DynamicData.ReactiveUI.Tests.Fixtures
 {

--- a/DynamicData.ReactiveUI.Tests/Fixtures/BindFromObservableListFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/BindFromObservableListFixture.cs
@@ -5,6 +5,8 @@ using FluentAssertions;
 using ReactiveUI.Legacy;
 using Xunit;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI.Tests.Fixtures
 {
     

--- a/DynamicData.ReactiveUI.Tests/Fixtures/BindSortedChangeSetFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/BindSortedChangeSetFixture.cs
@@ -9,6 +9,8 @@ using ReactiveUI;
 using ReactiveUI.Legacy;
 using Xunit;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI.Tests.Fixtures
 {
     

--- a/DynamicData.ReactiveUI.Tests/Fixtures/ObservableCollectionToObservableChangeSetWithoutINdexFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/ObservableCollectionToObservableChangeSetWithoutINdexFixture.cs
@@ -6,6 +6,8 @@ using ReactiveUI;
 using ReactiveUI.Legacy;
 using Xunit;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI.Tests.Fixtures
 {
 	

--- a/DynamicData.ReactiveUI.Tests/Fixtures/ToObservableChangeSetFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/ToObservableChangeSetFixture.cs
@@ -5,6 +5,8 @@ using ReactiveUI.Legacy;
 using Xunit;
 using FluentAssertions;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI.Tests.Fixtures
 {
 	

--- a/DynamicData.ReactiveUI.Tests/Fixtures/TransformManyFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/TransformManyFixture.cs
@@ -11,6 +11,8 @@ using ReactiveUI;
 using ReactiveUI.Legacy;
 using Xunit;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI.Tests.Fixtures
 {
     public class TransformManyFixture

--- a/DynamicData.ReactiveUI.Tests/Fixtures/TransformManyObservableCollectionFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/TransformManyObservableCollectionFixture.cs
@@ -7,6 +7,8 @@ using ReactiveUI;
 using ReactiveUI.Legacy;
 using Xunit;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI.Tests.Fixtures
 {
     

--- a/DynamicData.ReactiveUI.Tests/Fixtures/TransformManyObservableCollectionWithKeyFixture.cs
+++ b/DynamicData.ReactiveUI.Tests/Fixtures/TransformManyObservableCollectionWithKeyFixture.cs
@@ -9,6 +9,8 @@ using FluentAssertions;
 using ReactiveUI.Legacy;
 using Xunit;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI.Tests.Fixtures
 {
 

--- a/DynamicData.ReactiveUI/DynamicDataEx.cs
+++ b/DynamicData.ReactiveUI/DynamicDataEx.cs
@@ -2,10 +2,13 @@
 using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Reflection;
 using DynamicData.Annotations;
 using DynamicData.Cache.Internal;
 using DynamicData.List.Internal;
 using ReactiveUI.Legacy;
+
+#pragma warning disable CS0618 // Using legacy code.
 
 namespace DynamicData.ReactiveUI
 {
@@ -23,6 +26,7 @@ namespace DynamicData.ReactiveUI
         /// <param name="source">The source.</param>
         /// <param name="manyselector">The manyselector.</param>
         /// <param name="equalityComparer">Used when an item has been replaced to determine whether child items are the same as previous children</param>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source,
             Func<TSource, IReadOnlyReactiveList<TDestination>> manyselector,
             IEqualityComparer<TDestination> equalityComparer = null)
@@ -48,6 +52,7 @@ namespace DynamicData.ReactiveUI
         /// <param name="source">The source.</param>
         /// <param name="manyselector">The manyselector.</param>
         /// <param name="equalityComparer">Used when an item has been replaced to determine whether child items are the same as previous children</param>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source,
             Func<TSource, ReactiveList<TDestination>> manyselector,
             IEqualityComparer<TDestination> equalityComparer = null)
@@ -74,6 +79,7 @@ namespace DynamicData.ReactiveUI
         /// <param name="source">The source.</param>
         /// <param name="manyselector">The manyselector.</param>
         /// <param name="keySelector">The key selector which must be unique across all</param>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<IChangeSet<TDestination, TDestinationKey>> TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(
             this IObservable<IChangeSet<TSource, TSourceKey>> source,
             Func<TSource, ReactiveList<TDestination>> manyselector,
@@ -108,6 +114,7 @@ namespace DynamicData.ReactiveUI
         /// <param name="source">The source.</param>
         /// <param name="manyselector">The manyselector.</param>
         /// <param name="keySelector">The key selector which must be unique across all</param>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<IChangeSet<TDestination, TDestinationKey>> TransformMany<TDestination, TDestinationKey, TSource, TSourceKey>(
             this IObservable<IChangeSet<TSource, TSourceKey>> source,
             Func<TSource, IReadOnlyReactiveList<TDestination>> manyselector,
@@ -145,6 +152,7 @@ namespace DynamicData.ReactiveUI
         /// or
         /// targetCollection
         /// </exception>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<IChangeSet<T>> Bind<T>([NotNull] this IObservable<IChangeSet<T>> source,
             [NotNull] ReactiveList<T> targetCollection, int resetThreshold = 25)
         {
@@ -170,6 +178,7 @@ namespace DynamicData.ReactiveUI
         /// or
         /// target
         /// </exception>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source, ReactiveList<TObject> target,
             int resetThreshold = 25)
         {
@@ -190,6 +199,7 @@ namespace DynamicData.ReactiveUI
         /// <param name="updater">The updater.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException">source</exception>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<IChangeSet<TObject, TKey>> Bind<TObject, TKey>(this IObservable<IChangeSet<TObject, TKey>> source,
             IChangeSetAdaptor<TObject, TKey> updater)
         {
@@ -242,6 +252,7 @@ namespace DynamicData.ReactiveUI
         /// or
         /// target
         /// </exception>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(
             this IObservable<ISortedChangeSet<TObject, TKey>> source, ReactiveList<TObject> target,
             int resetThreshold = 25)
@@ -262,6 +273,7 @@ namespace DynamicData.ReactiveUI
         /// <param name="updater">The updater.</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException">source</exception>
+        [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
         public static IObservable<ISortedChangeSet<TObject, TKey>> Bind<TObject, TKey>(
             this IObservable<ISortedChangeSet<TObject, TKey>> source,
             ISortedChangeSetAdaptor<TObject, TKey> updater)

--- a/DynamicData.ReactiveUI/ObservableCacheToReactiveListAdaptor.cs
+++ b/DynamicData.ReactiveUI/ObservableCacheToReactiveListAdaptor.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using ReactiveUI;
 using ReactiveUI.Legacy;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI
 {
     /// <summary>

--- a/DynamicData.ReactiveUI/ObservableListToReactiveListAdaptor.cs
+++ b/DynamicData.ReactiveUI/ObservableListToReactiveListAdaptor.cs
@@ -2,6 +2,8 @@
 using ReactiveUI;
 using ReactiveUI.Legacy;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI
 {
     /// <summary>

--- a/DynamicData.ReactiveUI/ReactiveListEx.cs
+++ b/DynamicData.ReactiveUI/ReactiveListEx.cs
@@ -1,15 +1,19 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using DynamicData.Binding;
 using ReactiveUI;
 using ReactiveUI.Legacy;
+
+#pragma warning disable CS0618 // Using legacy code.
 
 namespace DynamicData.ReactiveUI
 {
     /// <summary>
     ///Reactive List extensions
     /// </summary>
+    [Obsolete("ReactiveList has been deprecated by the ReactiveUI team.")]
     public static class ReactiveListEx
     {
         /// <summary>
@@ -34,7 +38,7 @@ namespace DynamicData.ReactiveUI
         public static IObservable<IChangeSet<T>> ToObservableChangeSet<T>(this ReactiveList<T> source)
         {
             return source.ToObservableChangeSet<ReactiveList<T>, T>();
-		}
+        }
 
         /// <summary>
         /// Clones the ReactiveList from all changes

--- a/DynamicData.ReactiveUI/SortedReactiveListAdaptor.cs
+++ b/DynamicData.ReactiveUI/SortedReactiveListAdaptor.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using ReactiveUI;
 using ReactiveUI.Legacy;
 
+#pragma warning disable CS0618 // Using legacy code.
+
 namespace DynamicData.ReactiveUI
 {
     /// <summary>


### PR DESCRIPTION
Make the methods in the ReactiveUI section be regarded as Obsolete to external users.

Also reduced warnings with Obsolete warnings for the RxUI project. Made it explicit pragmas to make it obvious that we are suppressing it.