### PR TITLE
Add overload for TransformMany to support IObservableList

### DIFF
--- a/DynamicData.Tests/List/TransformManyObservableCollectionFixture.cs
+++ b/DynamicData.Tests/List/TransformManyObservableCollectionFixture.cs
@@ -7,8 +7,7 @@ using FluentAssertions;
 using Xunit;
 
 namespace DynamicData.Tests.List
-{
-    
+{    
     public class TransformManyObservableCollectionFixture
     {
         [Fact]
@@ -125,6 +124,65 @@ namespace DynamicData.Tests.List
         }
 
         [Fact]
+        public void FlattenObservableList()
+        {
+            var children = Enumerable.Range(1, 100).Select(i => new Person("Name" + i, i)).ToArray();
+
+            int childIndex = 0;
+            var parents = Enumerable.Range(1, 50)
+                .Select(i =>
+                {
+                    var parent = new ParentDynamic(i, new[]
+                    {
+                        children[childIndex],
+                        children[childIndex + 1]
+                    });
+
+                    childIndex = childIndex + 2;
+                    return parent;
+                }).ToArray();
+
+
+            using (var source = new SourceList<ParentDynamic>())
+            using (var aggregator = source.Connect()
+                .TransformMany(p => p.ChildrenObservable)
+                .AsAggregator())
+            {
+                T at<T>(IEnumerable<T> elements, int i) => elements.Skip(i).First();
+
+                source.AddRange(parents);
+
+                aggregator.Data.Count.Should().Be(100);
+
+                //add a child to an observable collection and check the new item is added
+                parents[0].Children.Add(new Person("NewlyAddded", 100));
+                aggregator.Data.Count.Should().Be(101);
+
+                ////remove first parent and check children have gone
+                source.RemoveAt(0);
+                aggregator.Data.Count.Should().Be(98);
+
+
+                //check items can be cleared and then added back in
+                var childrenInZero = parents[1].Children.Items.ToArray();
+                parents[1].Children.Clear();
+                aggregator.Data.Count.Should().Be(96);
+                parents[1].Children.AddRange(childrenInZero);
+                aggregator.Data.Count.Should().Be(98);
+
+                //replace produces an update
+                var replacedChild = at(parents[1].Children.Items, 0);
+                var replacement = new Person("Replacement", 100);
+                parents[1].Children.ReplaceAt(0, replacement);
+                aggregator.Data.Count.Should().Be(98);
+
+                //replace produces an update
+                aggregator.Data.Items.Contains(replacement).Should().BeTrue();
+                aggregator.Data.Items.Contains(replacedChild).Should().BeFalse();
+            }
+        }
+
+        [Fact]
         public void ObservableCollectionWithoutInitialData()
         {
             using (var parents = new SourceList<Parent>())
@@ -169,12 +227,33 @@ namespace DynamicData.Tests.List
             }
         }
 
+        [Fact]
+        public void ObservableListWithoutInitialData()
+        {
+            using (var parents = new SourceList<ParentDynamic>())
+            {
+                var collection = parents.Connect()
+                    .TransformMany(d => d.ChildrenObservable)
+                    .AsObservableList();
+
+                var parent = new ParentDynamic();
+                parents.Add(parent);
+
+                collection.Count.Should().Be(0);
+
+                parent.Children.Add(new Person("child1", 1));
+                collection.Count.Should().Be(1);
+
+                parent.Children.Add(new Person("child2", 2));
+                collection.Count.Should().Be(2);
+            }
+        }
 
         private class Parent
         {
             public ObservableCollection<Person> Children { get; }
             public ReadOnlyObservableCollection<Person> ChildrenReadonly { get; }
-
+            
             public Parent(int id, IEnumerable<Person> children)
             {
                 Children = new ObservableCollection<Person>(children);
@@ -185,6 +264,25 @@ namespace DynamicData.Tests.List
             {
                 Children = new ObservableCollection<Person>();
                 ChildrenReadonly = new ReadOnlyObservableCollection<Person>(Children);
+            }
+        }
+
+        private class ParentDynamic
+        {
+            public SourceList<Person> Children { get; }
+            public IObservableList<Person> ChildrenObservable { get; }
+
+            public ParentDynamic(int id, IEnumerable<Person> children)
+            {
+                Children = new SourceList<Person>();
+                Children.AddRange(children);
+                ChildrenObservable = Children.AsObservableList();
+            }
+
+            public ParentDynamic()
+            {
+                Children = new SourceList<Person>();
+                ChildrenObservable = Children.AsObservableList();
             }
         }
     }

--- a/DynamicData/List/Internal/TransformMany.cs
+++ b/DynamicData/List/Internal/TransformMany.cs
@@ -50,6 +50,20 @@ namespace DynamicData.List.Internal
         {
         }
 
+        public TransformMany(IObservable<IChangeSet<TSource>> source,
+            Func<TSource, IObservableList<TDestination>> manyselector,
+            IEqualityComparer<TDestination> equalityComparer = null)
+            : this(source, s => new DerivedEnumerable(s, x => manyselector(x).Items), equalityComparer, t => Observable.Defer(() => {
+                var subsequentChanges = manyselector(t).Connect();
+
+                if (manyselector(t).Count > 0)
+                    return subsequentChanges;
+
+                return Observable.Return(ChangeSet<TDestination>.Empty)
+                    .Concat(subsequentChanges);
+            }))
+        {
+        }
 
         public TransformMany([NotNull] IObservable<IChangeSet<TSource>> source,
             [NotNull] Func<TSource, IEnumerable<TDestination>> manyselector,
@@ -206,7 +220,20 @@ namespace DynamicData.List.Internal
                 return GetEnumerator();
             }
         }
+
+        private class DerivedEnumerable : IEnumerable<TDestination>
+        {
+            private TSource _source;
+            private Func<TSource, IEnumerable<TDestination>> _selector;
+
+            public DerivedEnumerable(TSource source, Func<TSource, IEnumerable<TDestination>> selector)
+            {
+                _source = source;
+                _selector = selector ?? throw new ArgumentNullException(nameof(selector));
+            }
+
+            public IEnumerator<TDestination> GetEnumerator() => _selector(_source).GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => _selector(_source).GetEnumerator();
+        }
     }
-
-
 }

--- a/DynamicData/List/Internal/TransformMany.cs
+++ b/DynamicData/List/Internal/TransformMany.cs
@@ -53,7 +53,7 @@ namespace DynamicData.List.Internal
         public TransformMany(IObservable<IChangeSet<TSource>> source,
             Func<TSource, IObservableList<TDestination>> manyselector,
             IEqualityComparer<TDestination> equalityComparer = null)
-            : this(source, s => new DerivedEnumerable(s, x => manyselector(x).Items), equalityComparer, t => Observable.Defer(() => {
+            : this(source, s => new ManySelectorFunc(s, x => manyselector(x).Items), equalityComparer, t => Observable.Defer(() => {
                 var subsequentChanges = manyselector(t).Connect();
 
                 if (manyselector(t).Count > 0)
@@ -221,12 +221,12 @@ namespace DynamicData.List.Internal
             }
         }
 
-        private class DerivedEnumerable : IEnumerable<TDestination>
+        private class ManySelectorFunc : IEnumerable<TDestination>
         {
             private TSource _source;
             private Func<TSource, IEnumerable<TDestination>> _selector;
 
-            public DerivedEnumerable(TSource source, Func<TSource, IEnumerable<TDestination>> selector)
+            public ManySelectorFunc(TSource source, Func<TSource, IEnumerable<TDestination>> selector)
             {
                 _source = source;
                 _selector = selector ?? throw new ArgumentNullException(nameof(selector));

--- a/DynamicData/List/ObservableListEx.cs
+++ b/DynamicData/List/ObservableListEx.cs
@@ -791,7 +791,21 @@ namespace DynamicData
         {
             return new TransformMany<TSource, TDestination>(source, manyselector, equalityComparer).Run();
         }
-        
+
+        /// <summary>
+        /// Flatten the nested observable list, and observe subsequent observable collection changes
+        /// </summary>
+        /// <typeparam name="TDestination">The type of the destination.</typeparam>
+        /// <typeparam name="TSource">The type of the source.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="manyselector">The manyselector.</param>
+        /// <param name="equalityComparer">Used when an item has been replaced to determine whether child items are the same as previous children</param>
+        public static IObservable<IChangeSet<TDestination>> TransformMany<TDestination, TSource>(this IObservable<IChangeSet<TSource>> source,
+            Func<TSource, IObservableList<TDestination>> manyselector,
+            IEqualityComparer<TDestination> equalityComparer = null)
+        {
+            return new TransformMany<TSource, TDestination>(source, manyselector, equalityComparer).Run();
+        }
 
         /// <summary>
         /// Selects distinct values from the source, using the specified value selector


### PR DESCRIPTION
- Added an extra constructor in TransformMany that accepts a `Func<TParent, IObservableList<TChild>>` as its `manyselector`. Since we want to be able to call the original `manyselector` again when the parent is removed (instead of remembering the value of `manyselector(x).Items` when the parent was added), I also added a small `ManySelectorFunc` class that captures the original selector.
- Added an overload of the TransformMany extension method too
- Duplicated and fixed the unit test for TransformMany to also test the new overloads