### PR TITLE
Expire after bug

### DIFF
--- a/DynamicData.Tests/Cache/ObservableToObservableChangeSetFixture.cs
+++ b/DynamicData.Tests/Cache/ObservableToObservableChangeSetFixture.cs
@@ -177,7 +177,7 @@ namespace DynamicData.Tests.Cache
             results.Data.Count.Should().Be(10, "Should be 10 items in the cache");
         }
 
-       // [Fact]
+        [Fact]
         public void ExpireAfterTimeDynamicWithKey()
         {
             var scheduler = new TestScheduler();

--- a/DynamicData/Cache/Internal/MergeMany.cs
+++ b/DynamicData/Cache/Internal/MergeMany.cs
@@ -26,7 +26,14 @@ namespace DynamicData.Cache.Internal
         {
             return Observable.Create<TDestination>
             (
-                observer => _source.SubscribeMany((t, key) => _observableSelector(t, key).Subscribe(observer))
+                observer => _source.SubscribeMany(
+                        (t, key) => _observableSelector(t, key)
+                            .Subscribe(
+                                observer.OnNext,
+                                ex => {},
+                                ( ) => {}
+                                )
+                        )
                     .Subscribe(t => { }, observer.OnError));
         }
     }


### PR DESCRIPTION
This PR is an attempt to resolve #187. 

I think the root cause of this issue was, that MergeMany propagates OnCompleted from all items to the outside observer. So when the first item's remove is executed and the observable started with Observable.Timer is completed, the overall stream is completed an the remove of subsequent items will not be executed.

Please review my changes to MergeMany. I am ignoring OnCompleted and OnError and I am not sure, if this is the correct thing to do.