### PR TITLE
Add FilterOnObservable

### DIFF
--- a/DynamicData.Tests/Domain/PersonObs.cs
+++ b/DynamicData.Tests/Domain/PersonObs.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reactive.Subjects;
+using DynamicData.Annotations;
+using DynamicData.Binding;
+
+namespace DynamicData.Tests.Domain
+{
+    public class PersonObs : IEquatable<PersonObs>
+    {
+        public string ParentName { get; }
+        public string Name { get; }
+        public string Gender { get; }
+        public string Key => Name;
+        [NotNull]
+        private readonly BehaviorSubject<int> _age;
+
+        public PersonObs(string firstname, string lastname, int age, string gender = "F", string parentName = null)
+            : this(firstname + " " + lastname, age, gender, parentName)
+        {
+        }
+
+        public PersonObs(string name, int age, string gender = "F", string parentName = null)
+        {
+            Name = name;
+            _age = new BehaviorSubject<int>(age);
+            Gender = gender;
+            ParentName = parentName ?? string.Empty;
+        }
+
+        public IObservable<int> Age => _age;
+
+        public void SetAge(int age)
+        {
+            _age.OnNext(age);
+        }
+
+        #region Equality Members
+
+        public bool Equals(PersonObs other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Name, other.Name);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((PersonObs)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Name != null ? Name.GetHashCode() : 0);
+        }
+
+        public static bool operator ==(PersonObs left, PersonObs right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(PersonObs left, PersonObs right)
+        {
+            return !Equals(left, right);
+        }
+
+        private sealed class AgeEqualityComparer : IEqualityComparer<PersonObs>
+        {
+            public bool Equals(PersonObs x, PersonObs y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (ReferenceEquals(x, null)) return false;
+                if (ReferenceEquals(y, null)) return false;
+                if (x.GetType() != y.GetType()) return false;
+                return x._age.Value == y._age.Value;
+            }
+
+            public int GetHashCode(PersonObs obj)
+            {
+                return obj._age.Value;
+            }
+        }
+
+        public static IEqualityComparer<PersonObs> AgeComparer { get; } = new AgeEqualityComparer();
+
+
+        private sealed class NameAgeGenderEqualityComparer : IEqualityComparer<PersonObs>
+        {
+            public bool Equals(PersonObs x, PersonObs y)
+            {
+                if (ReferenceEquals(x, y)) return true;
+                if (ReferenceEquals(x, null)) return false;
+                if (ReferenceEquals(y, null)) return false;
+                if (x.GetType() != y.GetType()) return false;
+                return string.Equals(x.Name, y.Name) && x._age == y._age && string.Equals(x.Gender, y.Gender);
+            }
+
+            public int GetHashCode(PersonObs obj)
+            {
+                unchecked
+                {
+                    var hashCode = (obj.Name != null ? obj.Name.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ obj._age.Value;
+                    hashCode = (hashCode * 397) ^ (obj.Gender != null ? obj.Gender.GetHashCode() : 0);
+                    return hashCode;
+                }
+            }
+        }
+
+        public static IEqualityComparer<PersonObs> NameAgeGenderComparer { get; } = new NameAgeGenderEqualityComparer();
+
+        #endregion
+
+        public override string ToString()
+        {
+            return $"{Name}. {_age.Value}";
+        }
+    }
+}

--- a/DynamicData.Tests/List/FilterOnObservableFixture.cs
+++ b/DynamicData.Tests/List/FilterOnObservableFixture.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Linq;
+using DynamicData.Tests.Domain;
+using FluentAssertions;
+using Xunit;
+
+namespace DynamicData.Tests.List
+{
+    public class FilterOnObservableFixture
+    {
+        [Fact]
+        public void InitialValues()
+        {
+            var people = Enumerable.Range(1, 100).Select(i => new PersonObs ("Name" + i, i)).ToArray();
+            using (var stub = new FilterPropertyStub())
+            {
+                stub.Source.AddRange(people);
+
+//                stub.Results.Messages.Count.Should().Be(1);
+                stub.Results.Data.Count.Should().Be(82);
+
+                stub.Results.Data.Items.ShouldAllBeEquivalentTo(people.Skip(18));
+            }
+        }
+
+        [Fact]
+        public void ChangeAValueToMatchFilter()
+        {
+            var people = Enumerable.Range(1, 100).Select(i => new PersonObs ("Name" + i, i)).ToArray();
+            using (var stub = new FilterPropertyStub())
+            {
+                stub.Source.AddRange(people);
+
+                people[20].SetAge(10);
+
+//                stub.Results.Messages.Count.Should().Be(2);
+                stub.Results.Data.Count.Should().Be(81);
+            }
+        }
+
+        [Fact]
+        public void ChangeAValueToNoLongerMatchFilter()
+        {
+            var people = Enumerable.Range(1, 100).Select(i => new PersonObs ("Name" + i, i)).ToArray();
+            using (var stub = new FilterPropertyStub())
+            {
+                stub.Source.AddRange(people);
+
+                people[10].SetAge(20);
+
+//                stub.Results.Messages.Count.Should().Be(2);
+                stub.Results.Data.Count.Should().Be(83);
+            }
+        }
+
+        [Fact]
+        public void ChangeAValueSoItIsStillInTheFilter()
+        {
+            var people = Enumerable.Range(1, 100).Select(i => new PersonObs ("Name" + i, i)).ToArray();
+            using (var stub = new FilterPropertyStub())
+            {
+                stub.Source.AddRange(people);
+
+                people[50].SetAge(100);
+//                stub.Results.Messages.Count.Should().Be(2);
+                stub.Results.Data.Count.Should().Be(82);
+            }
+        }
+
+        [Fact]
+        public void Clear()
+        {
+            var people = Enumerable.Range(1, 100).Select(i => new PersonObs ("Name" + i, i)).ToArray();
+            using (var stub = new FilterPropertyStub())
+            {
+                stub.Source.AddRange(people);
+                stub.Source.Clear();
+
+                stub.Results.Data.Count.Should().Be(0);
+            }
+        }
+
+
+        [Fact]
+        public void RemoveRange()
+        {
+            var people = Enumerable.Range(1, 100).Select(i => new PersonObs ("Name" + i, i)).ToArray();
+            using (var stub = new FilterPropertyStub())
+            {
+                stub.Source.AddRange(people);
+                stub.Source.RemoveRange(89,10);
+
+                stub.Results.Data.Count.Should().Be(72);
+            }
+        }
+
+        private class FilterPropertyStub : IDisposable
+        {
+            public ISourceList<PersonObs > Source { get; } = new SourceList<PersonObs >();
+            public ChangeSetAggregator<PersonObs > Results { get; }
+
+
+            public FilterPropertyStub()
+            {
+                Results = new ChangeSetAggregator<PersonObs >(Source.Connect().FilterOnObservable(p => p.Age, (o, p) => p > 18));
+            }
+
+            public void Dispose()
+            {
+                Source.Dispose();
+                Results.Dispose();
+            }
+        }
+    }
+}

--- a/DynamicData.Tests/List/FilterOnObservableFixture.cs
+++ b/DynamicData.Tests/List/FilterOnObservableFixture.cs
@@ -16,7 +16,7 @@ namespace DynamicData.Tests.List
             {
                 stub.Source.AddRange(people);
 
-//                stub.Results.Messages.Count.Should().Be(1);
+                stub.Results.Messages.Count.Should().Be(1);
                 stub.Results.Data.Count.Should().Be(82);
 
                 stub.Results.Data.Items.ShouldAllBeEquivalentTo(people.Skip(18));
@@ -33,7 +33,7 @@ namespace DynamicData.Tests.List
 
                 people[20].SetAge(10);
 
-//                stub.Results.Messages.Count.Should().Be(2);
+                stub.Results.Messages.Count.Should().Be(2);
                 stub.Results.Data.Count.Should().Be(81);
             }
         }
@@ -48,7 +48,7 @@ namespace DynamicData.Tests.List
 
                 people[10].SetAge(20);
 
-//                stub.Results.Messages.Count.Should().Be(2);
+                stub.Results.Messages.Count.Should().Be(2);
                 stub.Results.Data.Count.Should().Be(83);
             }
         }
@@ -62,7 +62,7 @@ namespace DynamicData.Tests.List
                 stub.Source.AddRange(people);
 
                 people[50].SetAge(100);
-//                stub.Results.Messages.Count.Should().Be(2);
+                stub.Results.Messages.Count.Should().Be(2);
                 stub.Results.Data.Count.Should().Be(82);
             }
         }

--- a/DynamicData/List/Internal/FilterOnObservable.cs
+++ b/DynamicData/List/Internal/FilterOnObservable.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using DynamicData.Annotations;
+using DynamicData.Binding;
+
+namespace DynamicData.List.Internal
+{
+    internal class FilterOnObservable<TObject, TProperty>
+    {
+        private readonly IObservable<IChangeSet<TObject>> _source;
+        private readonly Func<TObject,  IObservable<TProperty>> _reevaluator;
+        private readonly Func<TObject, TProperty, bool> _filter;
+        private readonly TimeSpan? _buffer;
+        private readonly IScheduler _scheduler;
+
+        public FilterOnObservable(IObservable<IChangeSet<TObject>> source,
+            Func<TObject,  IObservable<TProperty>> reevaluator,
+            Func<TObject, TProperty, bool> filter,
+            TimeSpan? buffer = null,
+            IScheduler scheduler = null)
+        {
+            _source = source ?? throw new ArgumentNullException(nameof(source));
+            _reevaluator = reevaluator ?? throw new ArgumentNullException(nameof(reevaluator));
+            _filter = filter;
+            _buffer = buffer;
+            _scheduler = scheduler;
+        }
+
+        private class ObjWithPropValue : IEquatable<ObjWithPropValue>
+        {
+            public TObject Obj;
+            public TProperty Prop;
+
+            public ObjWithPropValue(TObject obj, TProperty prop)
+            {
+                Obj = obj;
+                Prop = prop;
+            }
+
+            public bool Equals(ObjWithPropValue other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return EqualityComparer<TObject>.Default.Equals(Obj, other.Obj);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != this.GetType()) return false;
+                return Equals((ObjWithPropValue) obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return EqualityComparer<TObject>.Default.GetHashCode(Obj);
+            }
+        }
+
+        public IObservable<IChangeSet<TObject>> Run()
+        {
+            return Observable.Create<IChangeSet<TObject>>(observer =>
+            {
+                var locker = new object();
+
+                var allItems = new List<ObjWithPropValue>();
+
+                var shared = _source
+                    .Synchronize(locker)
+                    .Transform(v => new ObjWithPropValue(v, default))
+                    .Clone(allItems) //clone all items so we can look up the index when a change has been made
+                    .Publish();
+
+                //monitor each item observable and create change, carry the value of the observable property
+                IObservable<ObjWithPropValue> itemHasChanged = shared.MergeMany(v => _reevaluator(v.Obj)
+                    .Select(prop => new ObjWithPropValue(v.Obj, prop)));
+
+                //create a changeset, either buffered or one item at the time
+                IObservable<IEnumerable<ObjWithPropValue>> itemsChanged;
+                if (_buffer == null)
+                {
+                    itemsChanged = itemHasChanged.Select(t => new[] {t});
+                }
+                else
+                {
+                    itemsChanged = itemHasChanged.Buffer(_buffer.Value, _scheduler ?? Scheduler.Default)
+                        .Where(list => list.Any());
+                }
+
+                IObservable<IChangeSet<ObjWithPropValue>> requiresRefresh = itemsChanged.Synchronize(locker)
+                    .Select(items =>
+                    {
+                        //catch all the indices of items which have been refreshed
+                        return IndexOfMany(allItems,
+                            items,
+                            v => v.Obj,
+                            (t, idx) => new Change<ObjWithPropValue>(ListChangeReason.Refresh, t, idx));
+                    })
+                    .Select(changes => new ChangeSet<ObjWithPropValue>(changes));
+
+
+                //publish refreshes and underlying changes
+                var publisher = shared
+                    .Merge(requiresRefresh)
+                    .Filter(v => _filter(v.Obj, v.Prop))
+                    .Transform(v => v.Obj)
+                    .SubscribeSafe(observer);
+
+                return new CompositeDisposable(publisher, shared.Connect());
+            });
+        }
+
+        /// <summary>
+        /// Finds the index of many items as specified in the secondary enumerable.
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TResult">The type of the result.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="itemsToFind">The items to find.</param>
+        /// <param name="objectPropertyFunc">Object property to join on</param>
+        /// <param name="resultSelector">The result selector</param>
+        /// <returns>A result as specified by the result selector</returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// </exception>
+        public static IEnumerable<TResult> IndexOfMany<TObject, TObjectProp, TResult>(
+            [NotNull] IEnumerable<TObject> source, [NotNull] IEnumerable<TObject> itemsToFind,
+            Func<TObject, TObjectProp> objectPropertyFunc, [NotNull] Func<TObject, int, TResult> resultSelector)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (itemsToFind == null) throw new ArgumentNullException(nameof(itemsToFind));
+            if (resultSelector == null) throw new ArgumentNullException(nameof(resultSelector));
+
+            var indexed = source.Select((element, index) => new { Element = element, Index = index });
+            return itemsToFind
+                .Join(indexed, left => objectPropertyFunc(left), right => objectPropertyFunc(right.Element),
+                    (left, right) => resultSelector(left, right.Index));
+        }
+    }
+}

--- a/DynamicData/List/ObservableListEx.cs
+++ b/DynamicData/List/ObservableListEx.cs
@@ -625,6 +625,33 @@ namespace DynamicData
             return new FilterOnProperty<TObject, TProperty>(source, propertySelector, predicate, propertyChangedThrottle, scheduler).Run();
         }
 
+        /// <summary>
+        /// Filters source on the specified observable property using the specified predicate.
+        /// 
+        /// The filter will automatically reapply when a property changes 
+        /// </summary>
+        /// <typeparam name="TObject">The type of the object.</typeparam>
+        /// <typeparam name="TProperty">The type of the property.</typeparam>
+        /// <param name="source">The source.</param>
+        /// <param name="propertySelector">The property selector. When the property changes the filter specified will be re-evaluated</param>
+        /// <param name="predicate">A predicate based on the object which contains the changed property</param>
+        /// <param name="propertyChangedThrottle">The property changed throttle.</param>
+        /// <param name="scheduler">The scheduler used when throttling</param>
+        /// <returns></returns>
+        /// <exception cref="System.ArgumentNullException">
+        /// </exception>
+        public static IObservable<IChangeSet<TObject>> FilterOnObservable<TObject, TProperty>(this IObservable<IChangeSet<TObject>> source,
+            Func<TObject, IObservable<TProperty>> propertySelector,
+            Func<TObject, TProperty, bool> predicate,
+            TimeSpan? propertyChangedThrottle = null,
+            IScheduler scheduler = null)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (propertySelector == null) throw new ArgumentNullException(nameof(propertySelector));
+            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
+            return new FilterOnObservable<TObject, TProperty>(source, propertySelector, predicate, propertyChangedThrottle, scheduler).Run();
+        }
+
 
         /// <summary>
         /// Reverse sort of the changset

--- a/DynamicData/List/ObservableListEx.cs
+++ b/DynamicData/List/ObservableListEx.cs
@@ -631,27 +631,21 @@ namespace DynamicData
         /// The filter will automatically reapply when a property changes 
         /// </summary>
         /// <typeparam name="TObject">The type of the object.</typeparam>
-        /// <typeparam name="TProperty">The type of the property.</typeparam>
         /// <param name="source">The source.</param>
-        /// <param name="propertySelector">The property selector. When the property changes the filter specified will be re-evaluated</param>
-        /// <param name="predicate">A predicate based on the object which contains the changed property</param>
+        /// <param name="objectFilterObservable">The filter property selector. When the observable changes the filter will be re-evaluated</param>
         /// <param name="propertyChangedThrottle">The property changed throttle.</param>
         /// <param name="scheduler">The scheduler used when throttling</param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentNullException">
         /// </exception>
-        public static IObservable<IChangeSet<TObject>> FilterOnObservable<TObject, TProperty>(this IObservable<IChangeSet<TObject>> source,
-            Func<TObject, IObservable<TProperty>> propertySelector,
-            Func<TObject, TProperty, bool> predicate,
+        public static IObservable<IChangeSet<TObject>> FilterOnObservable<TObject>(this IObservable<IChangeSet<TObject>> source,
+            Func<TObject, IObservable<bool>> objectFilterObservable,
             TimeSpan? propertyChangedThrottle = null,
             IScheduler scheduler = null)
         {
             if (source == null) throw new ArgumentNullException(nameof(source));
-            if (propertySelector == null) throw new ArgumentNullException(nameof(propertySelector));
-            if (predicate == null) throw new ArgumentNullException(nameof(predicate));
-            return new FilterOnObservable<TObject, TProperty>(source, propertySelector, predicate, propertyChangedThrottle, scheduler).Run();
+            return new FilterOnObservable<TObject>(source, objectFilterObservable, propertyChangedThrottle, scheduler).Run();
         }
-
 
         /// <summary>
         /// Reverse sort of the changset


### PR DESCRIPTION
New operator that I based on AutoRefresh that allows for filtering on an object's observable property.
This is unlike the existing Filter which only works for normal properties or INPC properties.
I am not completely happy with the implementation, it generates N refresh changes for N object, if anyone has an idea for how to prevent this it would be great :)