### PR TITLE
Fix And operator

### DIFF
--- a/DynamicData.Tests/Cache/AndFixture.cs
+++ b/DynamicData.Tests/Cache/AndFixture.cs
@@ -95,5 +95,18 @@ namespace DynamicData.Tests.Cache
             _results.Data.Count.Should().Be(1, "Cache should have no items");
             _results.Data.Items.First().Should().Be(personUpdated, "Should be updated person");
         }
+
+        [Fact]
+        public void StartingWithNonEmptySourceProducesNoResult()
+        {
+            var person = new Person("Adult", 50);
+            _source1.AddOrUpdate(person);
+
+            using (var result = CreateObservable().AsAggregator())
+            {
+                _results.Messages.Count.Should().Be(0, "Should have no updates");
+                result.Data.Count.Should().Be(0, "Cache should have no items");
+            }
+        }
     }
 }

--- a/DynamicData.Tests/List/AndFixture.cs
+++ b/DynamicData.Tests/List/AndFixture.cs
@@ -90,5 +90,16 @@ namespace DynamicData.Tests.List
             _source1.Clear();
             _results.Data.Count.Should().Be(0);
         }
+
+        [Fact]
+        public void StartingWithNonEmptySourceProducesNoResult()
+        {
+            _source1.Add(1);
+
+            using (var result = CreateObservable().AsAggregator())
+            {
+                result.Data.Count.Should().Be(0);
+            }
+        }
     }
 }

--- a/DynamicData/List/Internal/Combiner.cs
+++ b/DynamicData/List/Internal/Combiner.cs
@@ -25,19 +25,20 @@ namespace DynamicData.List.Internal
             return Observable.Create<IChangeSet<T>>(observer =>
             {
                 var disposable = new CompositeDisposable();
-                var sourceLists = new List<ReferenceCountTracker<T>>();
+
                 var resultList = new ChangeAwareListWithRefCounts<T>();
 
                 lock (_locker)
                 {
-                    foreach (var item in _source)
-                    {
-                        var list = new ReferenceCountTracker<T>();
-                        sourceLists.Add(list);
+                    var sourceLists = Enumerable.Range(0, _source.Count)
+                        .Select(_ => new ReferenceCountTracker<T>())
+                        .ToList(); 
 
-                        disposable.Add(item.Synchronize(_locker).Subscribe(changes =>
+                    foreach (var pair in _source.Zip(sourceLists, (item, list) => new { Item = item, List = list }))
+                    {
+                        disposable.Add(pair.Item.Synchronize(_locker).Subscribe(changes =>
                         {
-                            CloneSourceList(list, changes);
+                            CloneSourceList(pair.List, changes);
 
                             var notifications = UpdateResultList(changes, sourceLists, resultList);
                             if (notifications.Count != 0)
@@ -45,6 +46,7 @@ namespace DynamicData.List.Internal
                         }));
                     }
                 }
+
                 return disposable;
             });
         }


### PR DESCRIPTION
`var result = firstSource.Connect().And(secondSource.Connect());`

if `firstSource` had items before `And `operation, they will appear in `result ` even if they are not presented in `secondSource`


