### PR TITLE
Add passthrough of refresh events to lists

### DIFF
--- a/DynamicData.Tests/List/OrFixture.cs
+++ b/DynamicData.Tests/List/OrFixture.cs
@@ -25,7 +25,27 @@ namespace DynamicData.Tests.List
         }
     }
 
-    
+    public class OrRefreshFixture
+    {
+        [Fact]
+        public void RefreshPassesThrough()
+        {
+            SourceList<Item> source1 = new SourceList<Item>();
+            source1.Add(new Item("A"));
+            SourceList<Item> source2 = new SourceList<Item>();
+            source2.Add(new Item("B"));
+            
+            var list = new List<IObservable<IChangeSet<Item>>> { source1.Connect().AutoRefresh(), source2.Connect().AutoRefresh() };
+            var results = list.Or().AsAggregator();
+            source1.Items.ElementAt(0).Name = "Test";
+
+            results.Data.Count.Should().Be(2);
+            results.Messages.Count.Should().Be(3);
+            results.Messages[2].Refreshes.Should().Be(1);
+            results.Messages[2].First().Item.Current.Should().Be(source1.Items.First());
+        }
+    }
+
     public abstract class OrFixtureBase: IDisposable
     {
         protected ISourceList<int> _source1;

--- a/DynamicData/List/Internal/Combiner.cs
+++ b/DynamicData/List/Internal/Combiner.cs
@@ -90,7 +90,13 @@ namespace DynamicData.List.Internal
                 if (shouldBeInResult)
                 {
                     if (!isInResult)
+                    {
                         resultList.Add(item);
+                    }
+                    else if (change.Reason == ListChangeReason.Refresh)
+                    {
+                        resultList.Refresh(change.Current);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
DynamicData has several methods to combine lists and caches, such as Or/And/...
When two caches A and B are combined into a resulting cache C, changes to either A and B automatically  take effect in C. If a property on an element of A or B changes, the resulting refresh notification is passed through by C. ([Combiner.cs:129](https://github.com/RolandPheasant/DynamicData/blob/master/DynamicData/Cache/Internal/Combiner.cs#L129))

Lists, however, do not have the same behaviour. The refresh event is silently dropped. This PR adds similar passthrough of refreshes behaviour to lists.